### PR TITLE
fix: Remove deprecated setup.py test setup preventing installation from github via pip

### DIFF
--- a/djangocms_versioning/test_utils/factories.py
+++ b/djangocms_versioning/test_utils/factories.py
@@ -9,7 +9,6 @@ from cms.models import Page, PageContent, PageUrl, Placeholder, TreeNode
 
 import factory
 from djangocms_text_ckeditor.models import Text
-
 from factory.fuzzy import FuzzyChoice, FuzzyInteger, FuzzyText
 
 from ..models import Version

--- a/djangocms_versioning/test_utils/factories.py
+++ b/djangocms_versioning/test_utils/factories.py
@@ -7,9 +7,9 @@ from django.contrib.sites.models import Site
 from cms import constants
 from cms.models import Page, PageContent, PageUrl, Placeholder, TreeNode
 
+import factory
 from djangocms_text_ckeditor.models import Text
 
-import factory
 from factory.fuzzy import FuzzyChoice, FuzzyInteger, FuzzyText
 
 from ..models import Version

--- a/setup.py
+++ b/setup.py
@@ -9,17 +9,6 @@ INSTALL_REQUIREMENTS = [
     "django-fsm>=2.6,<2.7"
 ]
 
-TEST_REQUIREMENTS = [
-    "djangocms_helper",
-    "pillow<=5.4.1",  # Requirement for tests to be passing in python 3.4
-    "djangocms-text-ckeditor",
-    "factory-boy",
-    "freezegun",
-    "lxml<=4.3.5",
-    "bs4",
-]
-
-
 setup(
     name="djangocms-versioning",
     packages=find_packages(),
@@ -40,10 +29,4 @@ setup(
     author_email="info@divio.ch",
     url="http://github.com/divio/djangocms-versioning",
     license="BSD",
-    zip_safe=False,
-    tests_require=TEST_REQUIREMENTS,
-    dependency_links=[
-        "http://github.com/divio/django-cms/tarball/release/4.0.x#egg=django-cms-4.0.0",
-        "https://github.com/divio/djangocms-text-ckeditor/tarball/support/4.0.x#egg=djangocms-text-ckeditor-4.0.x",
-    ]
 )

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,8 +5,11 @@ django-sekizai<2.0.0
 djangocms_helper
 factory-boy
 flake8
+freezegun
 isort
+lxml
 mock
+pillow
 pyflakes>=2.1.1
 python-dateutil
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,13 +1,13 @@
-# test libraries
+beautifulsoup4
 coverage
-pyflakes>=2.1.1
+django-classy-tags<2.0.0
+django-sekizai<2.0.0
+djangocms_helper
 flake8
 isort
 mock
+pyflakes>=2.1.1
 python-dateutil
-beautifulsoup4
-django-classy-tags<2.0.0
-django-sekizai<2.0.0
 
-# Get the lastest cms v4 compatible djangocms-text-ckeditor
+# Unreleased dependancies
 https://github.com/divio/djangocms-text-ckeditor/tarball/support/4.0.x#egg=djangocms-text-ckeditor

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,6 +3,7 @@ coverage
 django-classy-tags<2.0.0
 django-sekizai<2.0.0
 djangocms_helper
+factory-boy
 flake8
 isort
 mock

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -25,6 +25,7 @@ from cms.utils.urlutils import admin_reverse
 
 import pytz
 from bs4 import BeautifulSoup
+from freezegun import freeze_time
 
 import djangocms_versioning.helpers
 from djangocms_versioning import constants, helpers
@@ -46,7 +47,6 @@ from djangocms_versioning.test_utils.blogpost.cms_config import BlogpostCMSConfi
 from djangocms_versioning.test_utils.blogpost.models import BlogContent
 from djangocms_versioning.test_utils.polls.cms_config import PollsCMSConfig
 from djangocms_versioning.test_utils.polls.models import Answer, Poll, PollContent
-from freezegun import freeze_time
 
 
 class BaseStateTestCase(CMSTestCase):

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -6,9 +6,10 @@ from cms.api import add_plugin
 from cms.models import Placeholder, UserSettings
 from cms.test_utils.testcases import CMSTestCase
 
+from freezegun import freeze_time
+
 from djangocms_versioning.models import Version
 from djangocms_versioning.test_utils import factories
-from freezegun import freeze_time
 
 
 class HandlersTestCase(CMSTestCase):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,6 +5,8 @@ from django.utils.timezone import now
 
 from cms.test_utils.testcases import CMSTestCase
 
+from freezegun import freeze_time
+
 from djangocms_versioning.constants import DRAFT, PUBLISHED
 from djangocms_versioning.datastructures import VersionableItem, default_copy
 from djangocms_versioning.helpers import remove_published_where
@@ -12,7 +14,6 @@ from djangocms_versioning.models import Version, VersionQuerySet
 from djangocms_versioning.test_utils import factories
 from djangocms_versioning.test_utils.polls.cms_config import PollsCMSConfig
 from djangocms_versioning.test_utils.polls.models import Poll, PollContent
-from freezegun import freeze_time
 
 
 class CopyTestCase(CMSTestCase):

--- a/tests/test_states.py
+++ b/tests/test_states.py
@@ -3,11 +3,11 @@ from django.utils.timezone import now
 from cms.test_utils.testcases import CMSTestCase
 
 from django_fsm import TransitionNotAllowed
+from freezegun import freeze_time
 
 from djangocms_versioning import constants
 from djangocms_versioning.models import StateTracking, Version
 from djangocms_versioning.test_utils import factories
-from freezegun import freeze_time
 
 
 class TestVersionState(CMSTestCase):


### PR DESCRIPTION
The settings for allowing setup.py to test standalone without a venv are old and deprecated.