### PR TITLE
Fix: Field Ordering Added to Generic Versioning Mixin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,9 +4,6 @@ Changelog
 
 unreleased
 ==========
-
-0.0.32 (2022-01-05)
-===================
 * fix: Added field ordering to the generic versioning mixing
 
 0.0.31 (2021-11-24)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,10 @@ Changelog
 unreleased
 ==========
 
+0.0.32 (2022-01-05)
+===================
+* fix: Added field ordering to the generic versioning mixing
+
 0.0.31 (2021-11-24)
 ===================
 * fix: Remove forcing a Timezone (USE_TZ=False) for the test suite which doesn't help for projects where the TZ is not forced to True.

--- a/djangocms_versioning/admin.py
+++ b/djangocms_versioning/admin.py
@@ -144,8 +144,8 @@ class ExtendedVersionAdminMixin(VersioningAdminMixin):
     """
     Extended VersionAdminMixin for common/generic versioning admin items
 
-    CAVEAT: Ordered fields are implemented by this mixin, if custom ordering is added to any models that inherits thi Mixin
-    it will require accommodating/reimplementing this.
+    CAVEAT: Ordered fields are implemented by this mixin, if custom ordering is added to any models that
+    inherits this Mixin it will require accommodating/reimplementing this.
     """
 
     class Media:

--- a/djangocms_versioning/admin.py
+++ b/djangocms_versioning/admin.py
@@ -143,6 +143,9 @@ class VersioningAdminMixin:
 class ExtendedVersionAdminMixin(VersioningAdminMixin):
     """
     Extended VersionAdminMixin for common/generic versioning admin items
+
+    WARNING: This makes use of ordered fields, if custom ordering is on anything that inherits this,
+    it will require accommodating/reimplementing this.
     """
 
     class Media:
@@ -165,6 +168,7 @@ class ExtendedVersionAdminMixin(VersioningAdminMixin):
         """
         return self.get_version(obj).get_state_display()
 
+    get_versioning_state.admin_order_field = "versions__state"
     get_versioning_state.short_description = _("State")
 
     def get_author(self, obj):
@@ -175,6 +179,7 @@ class ExtendedVersionAdminMixin(VersioningAdminMixin):
         """
         return self.get_version(obj).created_by
 
+    get_author.admin_order_field = "versions__created_by"
     get_author.short_description = _("Author")
 
     def get_modified_date(self, obj):
@@ -185,6 +190,7 @@ class ExtendedVersionAdminMixin(VersioningAdminMixin):
         """
         return self.get_version(obj).modified
 
+    get_modified_date.admin_order_field = "versions__modified"
     get_modified_date.short_description = _("Modified")
 
     def _get_preview_url(self, obj):

--- a/tests/requirements/requirements_base.txt
+++ b/tests/requirements/requirements_base.txt
@@ -11,7 +11,7 @@ mock
 pillow
 pyflakes>=2.1.1
 python-dateutil
-djangocms-text-ckeditor==4.0.0dev5
 
 # Unreleased django-cms 4.0 compatible packages
 https://github.com/django-cms/django-cms/tarball/release/4.0.x#egg=django-cms
+https://github.com/divio/djangocms-text-ckeditor/tarball/support/4.0.x#egg=djangocms-text-ckeditor@50364c3a4b693fa93a8bfbd7152aff03a3849c1e

--- a/tests/requirements/requirements_base.txt
+++ b/tests/requirements/requirements_base.txt
@@ -14,4 +14,4 @@ python-dateutil
 
 # Unreleased django-cms 4.0 compatible packages
 https://github.com/django-cms/django-cms/tarball/release/4.0.x#egg=django-cms
-https://github.com/divio/djangocms-text-ckeditor/tarball/support/4.0.x#egg=djangocms-text-ckeditor@50364c3a4b693fa93a8bfbd7152aff03a3849c1e
+https://github.com/divio/djangocms-text-ckeditor/tarball/support/4.0.x@50364c3a4b693fa93a8bfbd7152aff03a3849c1e

--- a/tests/requirements/requirements_base.txt
+++ b/tests/requirements/requirements_base.txt
@@ -11,7 +11,7 @@ mock
 pillow
 pyflakes>=2.1.1
 python-dateutil
+djangocms-text-ckeditor==4.0.0dev5
 
 # Unreleased django-cms 4.0 compatible packages
 https://github.com/django-cms/django-cms/tarball/release/4.0.x#egg=django-cms
-https://github.com/divio/djangocms-text-ckeditor/tarball/support/4.0.x#egg=djangocms-text-ckeditor

--- a/tests/requirements/requirements_base.txt
+++ b/tests/requirements/requirements_base.txt
@@ -14,4 +14,4 @@ python-dateutil
 
 # Unreleased django-cms 4.0 compatible packages
 https://github.com/django-cms/django-cms/tarball/release/4.0.x#egg=django-cms
-https://github.com/divio/djangocms-text-ckeditor/tarball/support/4.0.x@50364c3a4b693fa93a8bfbd7152aff03a3849c1e#egg=djangocms-text-ckeditor
+https://github.com/django-cms/djangocms-text-ckeditor/tarball/50364c3a4b693fa93a8bfbd7152aff03a3849c1e#egg=djangocms-text-ckeditor

--- a/tests/requirements/requirements_base.txt
+++ b/tests/requirements/requirements_base.txt
@@ -14,4 +14,4 @@ python-dateutil
 
 # Unreleased django-cms 4.0 compatible packages
 https://github.com/django-cms/django-cms/tarball/release/4.0.x#egg=django-cms
-https://github.com/divio/djangocms-text-ckeditor/tarball/support/4.0.x@50364c3a4b693fa93a8bfbd7152aff03a3849c1e
+https://github.com/divio/djangocms-text-ckeditor/tarball/support/4.0.x@50364c3a4b693fa93a8bfbd7152aff03a3849c1e#egg=djangocms-text-ckeditor


### PR DESCRIPTION
Field ordering was missing in the generic admin mixing for state, author and modified date. This PR adds those. 