### PR TITLE
Release 0.0.33

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ Changelog
 
 unreleased
 ==========
+
+0.0.33 (2022-01-11)
+===================
 * fix: Page Content Extended models do no update the version modified date as they should.
 
 0.0.32 (2022-01-05)

--- a/djangocms_versioning/__init__.py
+++ b/djangocms_versioning/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.0.32"
+__version__ = "0.0.33"
 
 default_app_config = "djangocms_versioning.apps.VersioningConfig"


### PR DESCRIPTION
* fix: Page Content Extended models do no update the version modified date as they should.