### PR TITLE
[DRAFT] Fix: Disable extended admin mixin edit button when content isn't editable

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Unreleased
 * Django 3.0, 3.1 and 3.2 support added
 * Python 3.5 and 3.6 support removed
 * Django 1.11 support removed
+* fix: ExtendedVersionAdminMixin edit button throwing error when content is uneditable
 
 0.0.33 (2022-01-11)
 ===================

--- a/djangocms_versioning/__init__.py
+++ b/djangocms_versioning/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.0.33"
+__version__ = "0.0.34"
 
 default_app_config = "djangocms_versioning.apps.VersioningConfig"

--- a/djangocms_versioning/__init__.py
+++ b/djangocms_versioning/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.0.34"
+__version__ = "0.0.35"
 
 default_app_config = "djangocms_versioning.apps.VersioningConfig"

--- a/djangocms_versioning/admin.py
+++ b/djangocms_versioning/admin.py
@@ -238,8 +238,8 @@ class ExtendedVersionAdminMixin(VersioningAdminMixin):
             args=(version.pk,),
         )
         return render_to_string(
-            "djangocms_versioning/admin/edit_icon.html",
-            {"edit_url": url, "disabled": disabled},
+            "djangocms_versioning/admin/icons/edit_icon.html",
+            {"url": url, "disabled": disabled},
         )
 
     def _get_manage_versions_link(self, obj, request, disabled=False):

--- a/djangocms_versioning/admin.py
+++ b/djangocms_versioning/admin.py
@@ -238,8 +238,8 @@ class ExtendedVersionAdminMixin(VersioningAdminMixin):
             args=(version.pk,),
         )
         return render_to_string(
-            "djangocms_versioning/admin/icons/edit_icon.html",
-            {"url": url, "disabled": disabled, "get": False},
+            "djangocms_versioning/admin/edit_icon.html",
+            {"edit_url": url, "disabled": disabled},
         )
 
     def _get_manage_versions_link(self, obj, request, disabled=False):

--- a/djangocms_versioning/templates/djangocms_versioning/admin/edit_icon.html
+++ b/djangocms_versioning/templates/djangocms_versioning/admin/edit_icon.html
@@ -1,9 +1,9 @@
 {% load static i18n %}
 
 {% if disabled %}
-<a class="btn cms-versioning-action-btn inactive" title="{% trans "Edit" %}">
+<a class="btn cms-versioning-action-btn cms-versioning-action-edit inactive" title="{% trans "Edit" %}">
 {% else %}
-<a class="btn cms-versioning-action-btn js-versioning-action" href="{{ edit_url }}" title="{% trans "Edit" %}">
+<a class="btn cms-versioning-action-btn js-versioning-action cms-versioning-action-edit" href="{{ edit_url }}" title="{% trans "Edit" %}">
 {% endif %}
     <img src="{% static 'djangocms_versioning/svg/edit.svg' %}">
 </a>

--- a/djangocms_versioning/templates/djangocms_versioning/admin/edit_icon.html
+++ b/djangocms_versioning/templates/djangocms_versioning/admin/edit_icon.html
@@ -1,9 +1,9 @@
 {% load static i18n %}
 
 {% if disabled %}
-<a class="btn cms-versioning-action-btn cms-versioning-action-edit inactive" title="{% trans "Edit" %}">
+<a class="btn cms-versioning-action-btn inactive" title="{% trans "Edit" %}">
 {% else %}
-<a class="btn cms-versioning-action-btn js-versioning-action cms-versioning-action-edit" href="{{ edit_url }}" title="{% trans "Edit" %}">
+<a class="btn cms-versioning-action-btn js-versioning-action" href="{{ edit_url }}" title="{% trans "Edit" %}">
 {% endif %}
     <img src="{% static 'djangocms_versioning/svg/edit.svg' %}">
 </a>

--- a/djangocms_versioning/templates/djangocms_versioning/admin/icons/base.html
+++ b/djangocms_versioning/templates/djangocms_versioning/admin/icons/base.html
@@ -2,12 +2,16 @@
 <a
     title="{% block title %}{% endblock %}"
     class="btn
-{% if disabled %}
-    inactive
+    cms-versioning-action-btn
+    cms-versioning-action-{% block name %}{% endblock %}
+    {% if get|default_if_none:True %} cms-form-get-method {% endif %}
+    {% if action|default_if_none:True %} js-versioning-action{% endif %}
+    js-versioning-admin-keep-sideframe
+    {% if disabled %}
+    inactive"
 {% endif %}
-    cms-versioning-action-btn"
 {% if not disabled %}
-    href="{{ url }}"
+    " href="{{ url }}"
 {% endif %}
 >
     <img src="{% block icon %}{% endblock %}">

--- a/djangocms_versioning/templates/djangocms_versioning/admin/icons/base.html
+++ b/djangocms_versioning/templates/djangocms_versioning/admin/icons/base.html
@@ -5,11 +5,7 @@
 {% if disabled %}
     inactive
 {% endif %}
-    cms-versioning-action-btn
-    cms-versioning-action-{% block name %}{% endblock %}
-    {% if get|default_if_none:True %} cms-form-get-method {% endif %}
-    {% if action|default_if_none:True %} js-versioning-action{% endif %}
-    js-versioning-admin-keep-sideframe"
+    cms-versioning-action-btn"
 {% if not disabled %}
     href="{{ url }}"
 {% endif %}

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -2565,7 +2565,6 @@ class ListActionsTestCase(CMSTestCase):
 
         self.assertIn(expected_disabled_control, actual_disabled_control)
 
-
     def test_versions_list_action_active(self):
         """
         Version list admin action is rendered when enabled, with appropriate URL

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -2578,15 +2578,15 @@ class ListActionsTestCase(CMSTestCase):
                 model=proxy._meta.model_name
             )
         )
-        user = factories.UserFactory()
         request = RequestFactory().get("/admin/polls/pollcontent/")
-        request.user = user
+        request.user = factories.UserFactory()
 
         actual_enabled_manage_versions_control = self.modeladmin._get_manage_versions_link(
             draft_version.content, request,
         )
         expected_enabled_manage_versions_control = \
             '<a\n    title="Manage versions"\n    class="btn\n\n    cms-versioning-action-btn\n'
+
         self.assertIn(expected_enabled_manage_versions_control, actual_enabled_manage_versions_control)
         self.assertIn(f'href="{manage_versions_url}', actual_enabled_manage_versions_control)
 
@@ -2595,9 +2595,8 @@ class ListActionsTestCase(CMSTestCase):
         Version list admin action is rendered as disabled, without a URL
         """
         draft_version = factories.PollVersionFactory(state=constants.DRAFT)
-        user = factories.UserFactory()
         request = RequestFactory().get("/admin/polls/pollcontent/")
-        request.user = user
+        request.user = factories.UserFactory()
 
         actual_enabled_manage_versions_control = self.modeladmin._get_manage_versions_link(
             draft_version.content, request, disabled=True

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -2518,7 +2518,7 @@ class ExtendedVersionAdminTestCase(CMSTestCase):
         # Check list_action links are rendered
         self.assertContains(response, "cms-versioning-action-btn")
         self.assertContains(response, "cms-versioning-action-preview")
-        self.assertContains(response, 'title="Edit"')
+        self.assertContains(response, "cms-versioning-action-edit")
         self.assertContains(response, "cms-versioning-action-manage-versions")
         self.assertContains(response, "js-versioning-action")
 
@@ -2543,7 +2543,10 @@ class ListActionsTestCase(CMSTestCase):
             '<a class="btn cms-versioning-action-btn js-versioning-action"'
             ' href="%s" title="Edit">'
         ) % draft_edit_url
+        with self.login_user_context(user=self.get_superuser()):
+            response = self.client.get(draft_edit_url, follow=True)
 
+        # TODO: Do something with the response!
         self.assertIn(expected_enabled_state, actual_enabled_control)
 
     def test_edit_action_link_disabled_state(self):

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -431,7 +431,7 @@ class VersionAdminActionsTestCase(CMSTestCase):
             version, request, disabled=False
         )
         expected_enabled_state = (
-            '<a class="btn cms-versioning-action-btn js-versioning-action cms-versioning-action-edit"'
+            '<a class="btn cms-versioning-action-btn js-versioning-action"'
             ' href="%s" title="Edit">'
         ) % draft_edit_url
 
@@ -450,7 +450,7 @@ class VersionAdminActionsTestCase(CMSTestCase):
             version, request, disabled=True
         )
         expected_disabled_control = (
-            '<a class="btn cms-versioning-action-btn cms-versioning-action-edit inactive" title="Edit">'
+            '<a class="btn cms-versioning-action-btn inactive" title="Edit">'
         )
 
         self.assertIn(expected_disabled_control, actual_disabled_control)
@@ -2496,7 +2496,7 @@ class ExtendedVersionAdminTestCase(CMSTestCase):
         # Check list_action links are rendered
         self.assertContains(response, "cms-versioning-action-btn")
         self.assertContains(response, "cms-versioning-action-preview")
-        self.assertContains(response, "cms-versioning-action-edit")
+        self.assertContains(response, 'title="Edit"')
         self.assertContains(response, "cms-versioning-action-manage-versions")
         self.assertContains(response, "js-versioning-action")
 
@@ -2517,7 +2517,7 @@ class ExtendedVersionAdminTestCase(CMSTestCase):
         # Check list_action links are rendered
         self.assertContains(response, "cms-versioning-action-btn")
         self.assertContains(response, "cms-versioning-action-preview")
-        self.assertContains(response, "cms-versioning-action-edit")
+        self.assertContains(response, 'title="Edit"')
         self.assertContains(response, "cms-versioning-action-manage-versions")
         self.assertContains(response, "js-versioning-action")
 
@@ -2540,7 +2540,7 @@ class ListActionsTestCase(CMSTestCase):
             version.content, request, disabled=False
         )
         expected_enabled_state = (
-            '<a class="btn cms-versioning-action-btn js-versioning-action cms-versioning-action-edit"'
+            '<a class="btn cms-versioning-action-btn js-versioning-action"'
             ' href="%s" title="Edit">'
         ) % draft_edit_url
 
@@ -2552,14 +2552,14 @@ class ListActionsTestCase(CMSTestCase):
         """
         version = factories.PollVersionFactory(state=constants.DRAFT)
         user = factories.UserFactory()
-        request = RequestFactory().get("/admin/polls/blogcontent/")
+        request = RequestFactory().get("/admin/polls/pollcontent/")
         request.user = user
 
         actual_disabled_control = self.modeladmin._get_edit_link(
             version.content, request, disabled=True
         )
         expected_disabled_control = (
-            '<a class="btn cms-versioning-action-btn cms-versioning-action-edit inactive" title="Edit">'
+            '<a class="btn cms-versioning-action-btn inactive" title="Edit">'
         )
 
         self.assertIn(expected_disabled_control, actual_disabled_control)

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -2532,9 +2532,8 @@ class ListActionsTestCase(CMSTestCase):
         Editable content models render the edit endpoint as active, with a URL
         """
         version = factories.PollVersionFactory(state=constants.DRAFT)
-        user = factories.UserFactory()
         request = RequestFactory().get("/admin/polls/pollcontent/")
-        request.user = user
+        request.user = factories.UserFactory()
         draft_edit_url = reverse("admin:djangocms_versioning_pollcontentversion_edit_redirect", args=(version.pk,), )
 
         actual_enabled_control = self.modeladmin._get_edit_link(
@@ -2552,9 +2551,8 @@ class ListActionsTestCase(CMSTestCase):
         Un-editable content models render the edit endpoint as inactive, without a URL
         """
         version = factories.PollVersionFactory(state=constants.DRAFT)
-        user = factories.UserFactory()
         request = RequestFactory().get("/admin/polls/pollcontent/")
-        request.user = user
+        request.user = factories.UserFactory()
 
         actual_disabled_control = self.modeladmin._get_edit_link(
             version.content, request, disabled=True


### PR DESCRIPTION
Description
Error was being thrown when the edit button was pressed on uneditable content within any admin that used the ExtendedVersionAdminMixin. This was due to the wrong template being used in the _get_edit_link method. This PR also includes tests to cover the same criteria with the manage versions button. 


Related resources

<img width="1782" alt="Screenshot 2022-02-07 at 13 38 45" src="https://user-images.githubusercontent.com/5971953/152798859-039fd43e-fcbd-4ae1-8357-25ab3c1956ed.png">

[Added Here](https://github.com/django-cms/djangocms-versioning/commit/1c2ef9e4ae0bfd48db73e93572073bbd927f8c3e#diff-c3366f60f43af1ae0a294533004f87015a920b766af7133ae5ac52c50ad86b29R256)

- [x] I have opened this pull request against master
- [x]  I have added or modified the tests when changing logic
- [x]  I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
- [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst)and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.