### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ Changelog
 
 Unreleased
 ==========
+
+1.0.0 (2022-02-23)
+==================
 * Python 3.8, 3.9 support added
 * Django 3.0, 3.1 and 3.2 support added
 * Python 3.5 and 3.6 support removed

--- a/djangocms_versioning/__init__.py
+++ b/djangocms_versioning/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.0.33"
+__version__ = "1.0.0"
 
 default_app_config = "djangocms_versioning.apps.VersioningConfig"


### PR DESCRIPTION
* Python 3.8, 3.9 support added
* Django 3.0, 3.1 and 3.2 support added
* Python 3.5 and 3.6 support removed
* Django 1.11 support removed