### PR TITLE
ci: Update isort params for v5

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,4 +35,4 @@ jobs:
         uses: liskin/gh-problem-matcher-wrap@v1
         with:
           linters: isort
-          run: isort -c -rc -df ./
+          run: isort --check --diff ./

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 
 Unreleased
 ==========
+* ci: Updated isort params in lint workflow to meet current requirements.
 
 1.0.4 (2022-04-05)
 ==================


### PR DESCRIPTION
This updates the isort params for version 5.

https://pycqa.github.io/isort/docs/upgrade_guides/5.0.0.html