### PR TITLE
ci: Update actions to latest versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: 3.8
       - name: Install flake8
@@ -25,9 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: 3.8
       - run: python -m pip install isort

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,10 @@ jobs:
         ]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
 
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -34,4 +34,4 @@ jobs:
       run: coverage run setup.py test
 
     - name: Upload Coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 
 Unreleased
 ==========
+* ci: Update actions to v3 where possible, and coverage to v2 due to v1 sunset in Feb
 
 1.0.4 (2022-04-05)
 ==================

--- a/test_settings.py
+++ b/test_settings.py
@@ -50,6 +50,7 @@ HELPER_SETTINGS = {
     "PARLER_ENABLE_CACHING": False,
     "LANGUAGE_CODE": "en",
     "DEFAULT_AUTO_FIELD": "django.db.models.AutoField",
+    "CMS_CONFIRM_VERSION4": True
 }
 
 


### PR DESCRIPTION
Most actions are now at version 3 so this moves them on. Coverage is at version 2.