### PR TITLE
ci: Remove ``os`` from test workflow matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,6 @@ jobs:
             dj22_cms40.txt,
             dj32_cms40.txt,
         ]
-        os: [
-            ubuntu-20.04,
-        ]
 
     steps:
     - uses: actions/checkout@v1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 
 Unreleased
 ==========
+* ci: Remove ``os`` from test workflow matrix because it's unused
 
 1.0.4 (2022-04-05)
 ==================


### PR DESCRIPTION
Unused matrix option removed because the workflow always runs on latest ubuntu.

Checks marked as "Expected — Waiting for status to be reported" won't return a response because they're not going to run.

That's GH adding the OS from the matrix to the check name even though we never ran checks against the OS matrix values. I'll need to update the required checks once this is cleaned up.