### PR TITLE
ci: Added concurrency to workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,10 @@ name: Lint
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   flake8:
     name: flake8

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,10 @@ name: CodeCov
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit-tests:
     runs-on: ubuntu-latest

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 
 Unreleased
 ==========
+* ci: Added concurrency option to cancel in progress runs when new changes occur
 
 1.0.4 (2022-04-05)
 ==================


### PR DESCRIPTION
Adds concurrency option to workflows.

What this does is if new changes are pushed and workflows are running, they'll be cancelled because the code they're checking is then out of date so the results are no longer relevant.