### PR TITLE
feat: Adds a link to published content

### DIFF
--- a/djangocms_versioning/admin.py
+++ b/djangocms_versioning/admin.py
@@ -535,7 +535,10 @@ class VersionAdmin(admin.ModelAdmin):
             # Don't display the link if it isn't published
             return ""
 
-        published_url = obj.content.get_absolute_url()
+        try:
+            published_url = obj.content.get_absolute_url()
+        except AttributeError:
+            return ""
 
         return render_to_string(
             "djangocms_versioning/admin/published_icon.html",

--- a/djangocms_versioning/admin.py
+++ b/djangocms_versioning/admin.py
@@ -233,6 +233,12 @@ class ExtendedVersionAdminMixin(VersioningAdminMixin):
         :param request: The request to admin menu
         :return: Published link icon template
         """
+        version = proxy_model(self.get_version(obj), self.model)
+
+        if version.state != PUBLISHED:
+            # Don't display the link if it can't be edited
+            return ""
+
         published_url = self._get_published_url(obj)
 
         if not published_url:
@@ -530,12 +536,12 @@ class VersionAdmin(admin.ModelAdmin):
         )
 
     def _get_published_link(self, obj, request):
-        """Helper function to get the html link to the published page"""
-        if not obj.state == PUBLISHED:
-            # Don't display the link if it isn't published
-            return ""
-
+        """Helper function to get the link to the published page"""
         try:
+            if not obj.state == PUBLISHED:
+                # Don't display the link if it isn't published
+                return ""
+
             published_url = obj.content.get_absolute_url()
         except AttributeError:
             return ""

--- a/djangocms_versioning/admin.py
+++ b/djangocms_versioning/admin.py
@@ -239,7 +239,7 @@ class ExtendedVersionAdminMixin(VersioningAdminMixin):
             return ""
 
         return render_to_string(
-            "djangocms_versioning/admin/icons/published_icon.html",
+            "djangocms_versioning/admin/published_icon.html",
             {"published_url": published_url},
         )
 

--- a/djangocms_versioning/templates/djangocms_versioning/admin/published_icon.html
+++ b/djangocms_versioning/templates/djangocms_versioning/admin/published_icon.html
@@ -1,0 +1,6 @@
+{% load static i18n %}
+{% spaceless %}
+<a class="btn cms-form-get-method cms-versioning-action-btn js-versioning-action js-versioning-keep-sideframe" href="{{ published_url }}"
+   title="{% trans "View published" %}">
+<img src="{% static 'djangocms_versioning/svg/preview.svg' %}"></a>
+{% endspaceless %}

--- a/djangocms_versioning/templates/djangocms_versioning/admin/published_icon.html
+++ b/djangocms_versioning/templates/djangocms_versioning/admin/published_icon.html
@@ -1,6 +1,5 @@
 {% load static i18n %}
 {% spaceless %}
-<a class="btn cms-form-get-method cms-versioning-action-btn js-versioning-action js-versioning-keep-sideframe" href="{{ published_url }}"
-   title="{% trans "View published" %}">
+<a class="btn cms-form-get-method cms-versioning-action-btn js-versioning-action js-versioning-keep-sideframe" href="{{ published_url }}" title="{% trans "View published" %}">
 <img src="{% static 'djangocms_versioning/svg/preview.svg' %}"></a>
 {% endspaceless %}

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -608,6 +608,46 @@ class VersionAdminActionsTestCase(CMSTestCase):
             expected_disabled_control, actual_disabled_control.replace("\n", "")
         )
 
+    def test_action_published_link_visible_state(self):
+        """The published content link action is available"""
+        version = factories.PollVersionFactory(state=constants.PUBLISHED)
+        user = factories.UserFactory()
+        request = RequestFactory().get("/admin/polls/pollcontent/")
+        request.user = user
+        published_url = version.content.get_absolute_url()
+
+        expected_action_state = (
+            '<a class="btn cms-form-get-method cms-versioning-action-btn js-versioning-action '
+            'js-versioning-keep-sideframe" href="%s" title="View published">'
+        ) % published_url
+        actual_action_control = self.version_admin._get_published_link(version, request)
+
+        self.assertIn(expected_action_state, actual_action_control)
+
+    def test_action_published_link_not_visible_state(self):
+        """The published content link action is not available"""
+        version = factories.PollVersionFactory(state=constants.DRAFT)
+        user = factories.UserFactory()
+        request = RequestFactory().get("/admin/polls/pollcontent/")
+        request.user = user
+
+        expected_action_state = ''
+        actual_action_control = self.version_admin._get_published_link(version, request)
+
+        self.assertIn(expected_action_state, actual_action_control)
+
+    def test_action_published_link_not_valid_obj(self):
+        """The published content link is not applicable with this object"""
+        version = factories.AnswerFactory()
+        user = factories.UserFactory()
+        request = RequestFactory().get("/admin/polls/answer/")
+        request.user = user
+
+        expected_action_state = ''
+        actual_action_control = self.version_admin._get_published_link(version, request)
+
+        self.assertIn(expected_action_state, actual_action_control)
+
 
 class StateActionsTestCase(CMSTestCase):
     def test_archive_in_state_actions_for_draft_version(self):

--- a/tox.ini
+++ b/tox.ini
@@ -8,10 +8,8 @@ skip_missing_interpreters=True
 
 [testenv]
 deps =
-    -r{toxinidir}/tests/requirements/requirements_base.txt
-
-    dj22: -r{toxinidir}/tests/requirements/django_22.txt
-    dj32: -r{toxinidir}/tests/requirements/django_32.txt
+    dj22: -r{toxinidir}/tests/requirements/dj22_cms40.txt
+    dj32: -r{toxinidir}/tests/requirements/dj32_cms40.txt
 
 basepython =
     py37: python3.7


### PR DESCRIPTION
This adds an action button on the published content to take you to the content users will see via `get_absolute_url`.

How it looks with page content;
![Screenshot 2022-04-13 at 20 46 52](https://user-images.githubusercontent.com/1461191/163487688-38268d21-c6c1-4863-91c1-76bc0abb5e6a.png)

How it looks with Alias where `get_absolute_url` returns the preview URL;
<img width="306" alt="Screenshot 2022-04-14 at 17 11 21" src="https://user-images.githubusercontent.com/1461191/163487883-795cf0c1-ee68-4db8-823f-5ea250963de3.png">

