### PR TITLE
fix: The version changelist table edit button opens all items outside of the sideframe

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 
 Unreleased
 ==========
+* fix: Version Changelist table edit button opens all items out of the sideframe
 
 1.0.5 (2022-05-27)
 ==================

--- a/djangocms_versioning/admin.py
+++ b/djangocms_versioning/admin.py
@@ -522,15 +522,24 @@ class VersionAdmin(admin.ModelAdmin):
         if not obj.check_edit_redirect.as_bool(request.user):
             disabled = True
 
+        # Don't open in the sideframe if the item is not sideframe compatible
+        keep_sideframe = obj.versionable.content_model_is_sideframe_editable
+
         edit_url = reverse(
             "admin:{app}_{model}_edit_redirect".format(
                 app=obj._meta.app_label, model=self.model._meta.model_name
             ),
             args=(obj.pk,),
         )
+
         return render_to_string(
-            "djangocms_versioning/admin/edit_icon.html",
-            {"edit_url": edit_url, "disabled": disabled},
+            "djangocms_versioning/admin/icons/edit_icon.html",
+            {
+                "url": edit_url,
+                "disabled": disabled,
+                "get": False,
+                "keepsideframe": keep_sideframe
+            },
         )
 
     def _get_revert_link(self, obj, request, disabled=False):

--- a/djangocms_versioning/datastructures.py
+++ b/djangocms_versioning/datastructures.py
@@ -83,6 +83,24 @@ class VersionableItem(BaseVersionableItem):
         """Returns the grouper model class"""
         return self.grouper_field.remote_field.model
 
+    @cached_property
+    def content_model_is_sideframe_editable(self):
+        """Determine if a content model can be opened in the sideframe or not.
+
+        :return: Default True, False if the content model is not suitable for the sideframe
+        :rtype: bool
+        """
+        from cms.models import Placeholder
+
+        # Any models that contain a placeholder are deemed as not sideframe editing
+        # compatible i.e. they are toolbar enabled and contain placeholders. We can't
+        # use toolbar enabled status alone because any models that use version compare
+        # enable the toolbar to display.
+        for field in self.content_model._meta.get_fields(include_hidden=True):
+            if field.related_model == Placeholder:
+                return False
+        return True
+
     def distinct_groupers(self, **kwargs):
         """Returns a queryset of `self.content` objects with unique
         grouper objects.

--- a/djangocms_versioning/templates/djangocms_versioning/admin/edit_icon.html
+++ b/djangocms_versioning/templates/djangocms_versioning/admin/edit_icon.html
@@ -1,9 +1,0 @@
-{% load static i18n %}
-
-{% if disabled %}
-<a class="btn cms-versioning-action-btn inactive" title="{% trans "Edit" %}">
-{% else %}
-<a class="btn cms-versioning-action-btn js-versioning-action" href="{{ edit_url }}" title="{% trans "Edit" %}">
-{% endif %}
-    <img src="{% static 'djangocms_versioning/svg/edit.svg' %}">
-</a>

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -418,47 +418,52 @@ class VersionAdminActionsTestCase(CMSTestCase):
 
     def test_edit_action_link_enabled_state(self):
         """
-        The edit action is active
+        The edit action is active, a user can follow a link
         """
         version = factories.PollVersionFactory(state=constants.DRAFT)
-        user = factories.UserFactory()
         request = RequestFactory().get("/admin/polls/pollcontent/")
-        request.user = user
-        draft_edit_url = self.get_admin_url(
+        request.user = factories.UserFactory()
+        expected_disabled_control = "inactive"
+        expected_href = self.get_admin_url(
             self.versionable.version_model_proxy, "edit_redirect", version.pk
         )
 
-        actual_enabled_control = self.version_admin._get_edit_link(
+        edit_link = self.version_admin._get_edit_link(
             version, request, disabled=False
         )
-        expected_enabled_state = (
-            '<a class="btn cms-versioning-action-btn js-versioning-action"'
-            ' href="%s" title="Edit">'
-        ) % draft_edit_url
+        soup = BeautifulSoup(str(edit_link), features="lxml")
+        actual_link = soup.find("a")
+        actual_disabled_control = actual_link.get("class")
+        actual_href = actual_link.get("href")
 
-        self.assertIn(expected_enabled_state, actual_enabled_control)
+        self.assertIn(expected_href, actual_href)
+        self.assertNotIn(expected_disabled_control, actual_disabled_control)
 
     def test_edit_action_link_disabled_state(self):
         """
-        The edit action is disabled
+        The edit action is disabled, a user cannot follow a link
         """
         version = factories.PollVersionFactory(state=constants.DRAFT)
-        user = factories.UserFactory()
         request = RequestFactory().get("/admin/polls/pollcontent/")
-        request.user = user
+        request.user = factories.UserFactory()
+        expected_disabled_control = "inactive"
+        expected_href = None
 
-        actual_disabled_control = self.version_admin._get_edit_link(
+        edit_link = self.version_admin._get_edit_link(
             version, request, disabled=True
         )
-        expected_disabled_control = (
-            '<a class="btn cms-versioning-action-btn inactive" title="Edit">'
-        )
+        soup = BeautifulSoup(str(edit_link), features="lxml")
+        actual_link = soup.find("a")
+        actual_disabled_control = actual_link.get("class")
+        actual_href = actual_link.get("href")
 
         self.assertIn(expected_disabled_control, actual_disabled_control)
+        # No href should be present in the edit link when it is disabled
+        self.assertEqual(expected_href, actual_href)
 
     def test_revert_action_link_enable_state(self):
         """
-        The edit action is active
+        The revert action is active
         """
         version = factories.PollVersionFactory(state=constants.ARCHIVED)
         user = factories.UserFactory()
@@ -607,6 +612,56 @@ class VersionAdminActionsTestCase(CMSTestCase):
         self.assertIn(
             expected_disabled_control, actual_disabled_control.replace("\n", "")
         )
+
+    def test_edit_action_link_sideframe_editing_disabled_state(self):
+        """
+        Sideframe editing is disabled for objects with placeholders i.e. PageContent
+        """
+        version = factories.PageVersionFactory(state=constants.DRAFT)
+        request = RequestFactory().get("/")
+        request.user = factories.UserFactory()
+        expected_sideframe_open_control = "js-versioning-keep-sideframe"
+        expected_sideframe_close_control = "js-versioning-close-sideframe"
+        expected_href = self.get_admin_url(
+            self.versionable.version_model_proxy, "edit_redirect", version.pk
+        )
+
+        edit_link = self.version_admin._get_edit_link(
+            version, request, disabled=False
+        )
+        soup = BeautifulSoup(str(edit_link), features="lxml")
+        actual_link = soup.find("a")
+        actual_sideframe_control = actual_link.get("class")
+        actual_href = actual_link.get("href")
+
+        self.assertIn(expected_href, actual_href)
+        self.assertNotIn(expected_sideframe_open_control, actual_sideframe_control)
+        self.assertIn(expected_sideframe_close_control, actual_sideframe_control)
+
+    def test_edit_action_link_sideframe_editing_enabled_state(self):
+        """
+        Sideframe editing is enabled for all other objects without placeholders.
+        """
+        version = factories.PollVersionFactory(state=constants.DRAFT)
+        request = RequestFactory().get("/admin/polls/pollcontent/")
+        request.user = factories.UserFactory()
+        expected_sideframe_open_control = "js-versioning-keep-sideframe"
+        expected_sideframe_close_control = "js-versioning-close-sideframe"
+        expected_href = self.get_admin_url(
+            self.versionable.version_model_proxy, "edit_redirect", version.pk
+        )
+
+        edit_link = self.version_admin._get_edit_link(
+            version, request, disabled=False
+        )
+        soup = BeautifulSoup(str(edit_link), features="lxml")
+        actual_link = soup.find("a")
+        actual_sideframe_control = actual_link.get("class")
+        actual_href = actual_link.get("href")
+
+        self.assertIn(expected_href, actual_href)
+        self.assertIn(expected_sideframe_open_control, actual_sideframe_control)
+        self.assertNotIn(expected_sideframe_close_control, actual_sideframe_control)
 
 
 class StateActionsTestCase(CMSTestCase):

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -2,6 +2,7 @@ import copy
 
 from django.apps import apps
 
+from cms.models import PageContent
 from cms.test_utils.testcases import CMSTestCase
 
 from djangocms_versioning.constants import ARCHIVED, PUBLISHED
@@ -105,6 +106,30 @@ class VersionableItemTestCase(CMSTestCase):
         )
 
         self.assertEqual(versionable.grouper_model, Poll)
+
+    def test_content_model_is_sideframe_editable_for_sideframe_disabled_model(self):
+        """
+        A content model with placeholders should not be opened in the sideframe
+        """
+        versionable = VersionableItem(
+            content_model=PageContent,
+            grouper_field_name="page",
+            copy_function=default_copy,
+        )
+
+        self.assertEqual(versionable.content_model_is_sideframe_editable, False)
+
+    def test_content_model_is_sideframe_editable_for_sideframe_enabled_model(self):
+        """
+        A content model without placeholders should be opened in the sideframe
+        """
+        versionable = VersionableItem(
+            content_model=PollContent,
+            grouper_field_name="poll",
+            copy_function=default_copy,
+        )
+
+        self.assertEqual(versionable.content_model_is_sideframe_editable, True)
 
 
 class VersionableItemProxyModelTestCase(CMSTestCase):


### PR DESCRIPTION
## Description

An issue is present where all items in the Version Changelist table are opened outside of the sideframe when the edit icon is clicked. This should only be the case for PageContents and any other items with Placeholders that require a dedicated edit endpoint with a toolbar. All other items should continue to open in the sideframe. 

Due to the nature of the check, the caching (cached property) prevents the calculation happening for every table row when rendering the Changelist, it is done once per model with VersioningItem configuration. 

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
