### PR TITLE
Release 1.0.6

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ Changelog
 
 Unreleased
 ==========
+
+1.0.6 (2022-05-31)
+==================
 * fix: Version Changelist table edit button opens all items out of the sideframe
 
 1.0.5 (2022-05-27)

--- a/djangocms_versioning/__init__.py
+++ b/djangocms_versioning/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "1.0.5"
+__version__ = "1.0.6"
 
 default_app_config = "djangocms_versioning.apps.VersioningConfig"


### PR DESCRIPTION
* fix: Version Changelist table edit button opens all items out of the sideframe