### PR TITLE
feat: Add a 'View Published' button for page edit or preview mode

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 
 Unreleased
 ==========
+* feat: Add View Published button for page edit or preview mode
 
 1.0.6 (2022-05-31)
 ==================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ Changelog
 
 Unreleased
 ==========
+
+1.0.6 (2022-05-31)
+==================
 * fix: Version Changelist table edit button opens all items out of the sideframe
 
 1.0.5 (2022-05-27)

--- a/djangocms_versioning/__init__.py
+++ b/djangocms_versioning/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "1.0.5"
+__version__ = "1.0.6"
 
 default_app_config = "djangocms_versioning.apps.VersioningConfig"

--- a/djangocms_versioning/cms_toolbars.py
+++ b/djangocms_versioning/cms_toolbars.py
@@ -165,7 +165,7 @@ class VersioningToolbar(PlaceholderToolbar):
         if not published_version:
             return
 
-        if (self.toolbar.edit_mode_active or self.toolbar.preview_mode_active) and published_version:
+        if self.toolbar.edit_mode_active or self.toolbar.preview_mode_active:
             item = ButtonList(side=self.toolbar.RIGHT)
             item.add_button(
                 _("View Published"),

--- a/djangocms_versioning/cms_toolbars.py
+++ b/djangocms_versioning/cms_toolbars.py
@@ -22,12 +22,13 @@ from cms.utils.conf import get_cms_setting
 from cms.utils.i18n import get_language_dict, get_language_tuple
 from cms.utils.urlutils import add_url_parameters, admin_reverse
 
+from djangocms_versioning.constants import DRAFT, PUBLISHED
 from djangocms_versioning.helpers import (
     get_latest_admin_viewable_page_content,
     version_list_url,
 )
 from djangocms_versioning.models import Version
-from .constants import DRAFT, PUBLISHED
+
 
 
 VERSIONING_MENU_IDENTIFIER = "version"

--- a/djangocms_versioning/cms_toolbars.py
+++ b/djangocms_versioning/cms_toolbars.py
@@ -22,7 +22,7 @@ from cms.utils.conf import get_cms_setting
 from cms.utils.i18n import get_language_dict, get_language_tuple
 from cms.utils.urlutils import add_url_parameters, admin_reverse
 
-from djangocms_versioning.constants import DRAFT, PUBLISHED
+from djangocms_versioning.constants import PUBLISHED
 from djangocms_versioning.helpers import (
     get_latest_admin_viewable_page_content,
     version_list_url,

--- a/djangocms_versioning/test_utils/test_helpers.py
+++ b/djangocms_versioning/test_utils/test_helpers.py
@@ -34,15 +34,15 @@ def get_toolbar(content_obj, user=None, **kwargs):
     # Set the toolbar mode
     if kwargs.get("edit_mode", False):
         toolbar.toolbar.edit_mode_active = True
-        toolbar.toolbar.content_mode_active = False
+        toolbar.toolbar.preview_mode_active = False
         toolbar.toolbar.structure_mode_active = False
     elif kwargs.get("preview_mode", False):
         toolbar.toolbar.edit_mode_active = False
-        toolbar.toolbar.content_mode_active = True
+        toolbar.toolbar.preview_mode_active = True
         toolbar.toolbar.structure_mode_active = False
     elif kwargs.get("structure_mode", False):
         toolbar.toolbar.edit_mode_active = False
-        toolbar.toolbar.content_mode_active = False
+        toolbar.toolbar.preview_mode_active = False
         toolbar.toolbar.structure_mode_active = True
     toolbar.populate()
     return toolbar

--- a/tests/test_toolbars.py
+++ b/tests/test_toolbars.py
@@ -1,4 +1,5 @@
 from django.contrib.auth.models import Permission
+from django.utils.text import slugify
 
 from cms.cms_toolbars import LANGUAGE_MENU_IDENTIFIER, PlaceholderToolbar
 from cms.test_utils.testcases import CMSTestCase
@@ -13,6 +14,7 @@ from djangocms_versioning.test_utils.factories import (
     FancyPollFactory,
     PageContentWithVersionFactory,
     PageVersionFactory,
+    PageUrlFactory,
     PollVersionFactory,
     UserFactory,
 )
@@ -302,6 +304,32 @@ class VersioningToolbarTestCase(CMSTestCase):
         )
 
         self.assertEqual(expected_label, version_menu.name)
+
+    # def test_view_published_in_toolbar_in_edit_mode(self):
+    #     # Add page url to the version and check the view published for edit/preview mode
+    #     pagecontent_version = PageVersionFactory(content__template="")
+    #     PageUrlFactory(
+    #         page=self.pagecontent_version.content.page,
+    #         language='en',
+    #         path=slugify('test_page'),
+    #         slug=slugify('test_page'),
+    #     )
+    #     pagecontent_version.publish(user=self.get_superuser())
+    #     draft_version = pagecontent_version.copy(self.get_superuser())
+    #     url = get_object_edit_url(draft_version.content)
+    #
+    #
+    #     with self.login_user_context(self.get_superuser()):
+    #         response = self.client.get(url)
+    #
+    #     found_button_list = find_toolbar_buttons("View Published", response.wsgi_request.toolbar)
+    #     import pdb;pdb.set_trace()
+    #
+    #
+    #     # check View Published button exists
+    #     self.assertEqual(len(found_button_list), 1)
+    #     # The only edit button that exists is the versioning button
+    #     # self.assertEqual(found_button_list[0].url, edit_url)
 
 
 class VersioningPageToolbarTestCase(CMSTestCase):

--- a/tests/test_toolbars.py
+++ b/tests/test_toolbars.py
@@ -13,8 +13,8 @@ from djangocms_versioning.test_utils.factories import (
     BlogPostVersionFactory,
     FancyPollFactory,
     PageContentWithVersionFactory,
-    PageVersionFactory,
     PageUrlFactory,
+    PageVersionFactory,
     PollVersionFactory,
     UserFactory,
 )
@@ -310,24 +310,24 @@ class VersioningToolbarTestCase(CMSTestCase):
         The 'View Published' control is only relevant for pages that
         are published
         """
-        draft_version = PageVersionFactory(content__language="en", state=PUBLISHED)
-        toolbar = get_toolbar(draft_version.content, edit_mode=True)
+        published_version = PageVersionFactory(content__language="en", state=PUBLISHED)
+        toolbar = get_toolbar(published_version.content, edit_mode=True)
 
         toolbar.post_template_populate()
 
-        self.assertFalse(toolbar_button_exists("View Published", toolbar.toolbar))
+        self.assertTrue(toolbar_button_exists("View Published", toolbar.toolbar))
 
     def test_view_published_in_toolbar_in_preview_mode_for_published_page(self):
         """
         The 'View Published' control is only relevant for pages that
         are published
         """
-        draft_version = PageVersionFactory(content__language="en", state=PUBLISHED)
-        toolbar = get_toolbar(draft_version.content, preview_mode=True)
+        published_version = PageVersionFactory(content__language="en", state=PUBLISHED)
+        toolbar = get_toolbar(published_version.content, preview_mode=True)
 
         toolbar.post_template_populate()
 
-        self.assertFalse(toolbar_button_exists("View Published", toolbar.toolbar))
+        self.assertTrue(toolbar_button_exists("View Published", toolbar.toolbar))
 
     def test_view_published_not_in_toolbar_in_edit_mode_for_draft_page(self):
         """


### PR DESCRIPTION
## Description

Added a new button to the toolbar for pages that allows a user to navigate to the live url with ease.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* Initial implementation taken from: https://github.com/django-cms/djangocms-versioning/pull/281

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
