### PR TITLE
fix: Admin burger menu excluding Preview and Edit buttons in all languages

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 
 Unreleased
 ==========
+* fix: Admin burger menu excluding Preview and Edit buttons in all languages
 
 1.2.1 (2022-06-13)
 ==================

--- a/djangocms_versioning/static/djangocms_versioning/js/actions.js
+++ b/djangocms_versioning/static/djangocms_versioning/js/actions.js
@@ -108,8 +108,9 @@
             /* get the existing actions and move them into the options container */
             $(actions[0]).children('.cms-versioning-action-btn').each(function (index, item) {
 
-              /* exclude some buttons */
-              if (item.title == "Preview" || item.title == "Edit") {
+              /* exclude preview and edit buttons */
+              if (item.classList.contains('cms-versioning-action-preview') ||
+                  item.classList.contains('cms-versioning-action-edit')) {
                 return;
               }
 


### PR DESCRIPTION
## Description

The admin burger menu does not work for any other language than English. This is an issue where the Preview and Edit buttons are added to the burger menu and any bound js events are stripped because a new dom element is created. 

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->


## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
