### PR TITLE
feat: Compat with cms page content extension changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+ci:
+  autofix_prs: false
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: check-merge-conflict
+      - id: mixed-line-ending
+
+  - repo: https://github.com/PyCQA/flake8
+    rev: 4.0.1
+    hooks:
+      - id: flake8
+        additional_dependencies:
+          - flake8-broken-line
+          - flake8-bugbear
+          - flake8-builtins
+          - flake8-eradicate
+          - flake8-tidy-imports
+          - pep8-naming
+
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,9 @@ Changelog
 Unreleased
 ==========
 
+* feat: Compatibility with page content extension changes to django-cms
+* ci: Added basic linting pre-commit hooks
+
 1.2.2 (2022-07-20)
 ==================
 * fix: Admin burger menu excluding Preview and Edit buttons in all languages

--- a/djangocms_versioning/monkeypatch/extensions.py
+++ b/djangocms_versioning/monkeypatch/extensions.py
@@ -3,10 +3,12 @@ from django.core.exceptions import PermissionDenied
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 
+
 try:
     from cms.extensions.admin import TitleExtensionAdmin
 except ImportError:
     from cms.extensions.admin import PageContentExtensionAdmin
+
 from cms.extensions.extension_pool import ExtensionPool
 from cms.models import PageContent
 from cms.utils.page_permissions import user_can_change_page
@@ -49,6 +51,7 @@ def _copy_content_extensions(self, source_page, target_page, language, clone=Fal
             else:
                 instance.copy_to_public(target_title, language)
 
+
 # Compat for change in django-cms
 try:
     # Original v4 attribute
@@ -84,10 +87,10 @@ def _save_model(self, request, obj, form, change):
     except NameError:
         super(PageContentExtensionAdmin, self).save_model(request, obj, form, change)
 
-
     # Ensure that we update the version modified date of the attached version
     if title:
         _update_modified(title)
+
 
 try:
     TitleExtensionAdmin.save_model = _save_model

--- a/djangocms_versioning/monkeypatch/extensions.py
+++ b/djangocms_versioning/monkeypatch/extensions.py
@@ -3,7 +3,10 @@ from django.core.exceptions import PermissionDenied
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 
-from cms.extensions.admin import TitleExtensionAdmin
+try:
+    from cms.extensions.admin import TitleExtensionAdmin
+except ImportError:
+    from cms.extensions.admin import PageContentExtensionAdmin
 from cms.extensions.extension_pool import ExtensionPool
 from cms.models import PageContent
 from cms.utils.page_permissions import user_can_change_page
@@ -11,7 +14,7 @@ from cms.utils.page_permissions import user_can_change_page
 from djangocms_versioning.handlers import _update_modified
 
 
-def _copy_title_extensions(self, source_page, target_page, language, clone=False):
+def _copy_content_extensions(self, source_page, target_page, language, clone=False):
     """
     djangocms-cms/extensions/admin.py, last changed in: divio/django-cms@2894ae8
 
@@ -24,21 +27,35 @@ def _copy_title_extensions(self, source_page, target_page, language, clone=False
         page=source_page, language=language
     ).first()
     if target_page:
-        # the line below has been modified to accomodate versioning.
+        # the line below has been modified to accommodate versioning.
         target_title = PageContent._original_manager.filter(
             page=target_page, language=language
         ).first()
     else:
         target_title = source_title.publisher_public
-    for extension in self.title_extensions:
+
+    # Compat for change in django-cms
+    try:
+        # Original v4 attribute
+        extensions = self.title_extensions
+    except AttributeError:
+        # Updated v4 attribute based on `PageContent` extension name change
+        extensions = self.page_content_extensions
+
+    for extension in extensions:
         for instance in extension.objects.filter(extended_object=source_title):
             if clone:
                 instance.copy(target_title, language)
             else:
                 instance.copy_to_public(target_title, language)
 
-
-ExtensionPool._copy_title_extensions = _copy_title_extensions
+# Compat for change in django-cms
+try:
+    # Original v4 attribute
+    ExtensionPool._copy_title_extensions = _copy_content_extensions
+except AttributeError:
+    # Updated v4 attribute based on `PageContent` extension name change
+    ExtensionPool._copy_content_extensions = _copy_content_extensions
 
 
 def _save_model(self, request, obj, form, change):
@@ -62,14 +79,20 @@ def _save_model(self, request, obj, form, change):
     if not user_can_change_page(request.user, page=title.page):
         raise PermissionDenied()
 
-    super(TitleExtensionAdmin, self).save_model(request, obj, form, change)
+    try:
+        super(TitleExtensionAdmin, self).save_model(request, obj, form, change)
+    except NameError:
+        super(PageContentExtensionAdmin, self).save_model(request, obj, form, change)
+
 
     # Ensure that we update the version modified date of the attached version
     if title:
         _update_modified(title)
 
-
-TitleExtensionAdmin.save_model = _save_model
+try:
+    TitleExtensionAdmin.save_model = _save_model
+except NameError:
+    PageContentExtensionAdmin.save_model = _save_model
 
 
 @csrf_protect_m
@@ -95,7 +118,13 @@ def _add_view(self, request, form_url='', extra_context=None):
             return HttpResponseRedirect(change_url)
         except self.model.DoesNotExist:
             pass
-    return super(TitleExtensionAdmin, self).add_view(request, form_url, extra_context)
+    try:
+        return super(TitleExtensionAdmin, self).add_view(request, form_url, extra_context)
+    except NameError:
+        return super(PageContentExtensionAdmin, self).add_view(request, form_url, extra_context)
 
 
-TitleExtensionAdmin.add_view = _add_view
+try:
+    TitleExtensionAdmin.add_view = _add_view
+except NameError:
+    PageContentExtensionAdmin.add_view = _add_view

--- a/djangocms_versioning/monkeypatch/page.py
+++ b/djangocms_versioning/monkeypatch/page.py
@@ -3,6 +3,8 @@ from django.contrib.auth import get_user_model
 
 from cms import api
 from cms.models import Placeholder, pagemodel
+
+
 # Compat for change in django-cms
 try:
     # Original v4 module
@@ -10,6 +12,7 @@ try:
 except ImportError:
     # Updated v4 attribute based on content models module name change
     from cms.models import contentmodels
+
 from cms.utils.permissions import _thread_locals
 
 from djangocms_versioning.models import Version
@@ -33,6 +36,7 @@ def _get_page_content_cache(func):
         return language
 
     return inner
+
 
 try:
     pagemodel.Page._get_title_cache = _get_page_content_cache(

--- a/djangocms_versioning/monkeypatch/page.py
+++ b/djangocms_versioning/monkeypatch/page.py
@@ -2,7 +2,14 @@ from django.apps import apps
 from django.contrib.auth import get_user_model
 
 from cms import api
-from cms.models import Placeholder, pagemodel, titlemodels
+from cms.models import Placeholder, pagemodel
+# Compat for change in django-cms
+try:
+    # Original v4 module
+    from cms.models import titlemodels
+except ImportError:
+    # Updated v4 attribute based on content models module name change
+    from cms.models import contentmodels
 from cms.utils.permissions import _thread_locals
 
 from djangocms_versioning.models import Version
@@ -13,26 +20,36 @@ User = get_user_model()
 cms_extension = apps.get_app_config("cms").cms_extension
 
 
-def _get_title_cache(func):
+def _get_page_content_cache(func):
     def inner(self, language, fallback, force_reload):
         prefetch_cache = getattr(self, "_prefetched_objects_cache", {})
         cached_page_content = prefetch_cache.get("pagecontent_set", [])
         for page_content in cached_page_content:
-            self.title_cache[page_content.language] = page_content
+            try:
+                self.title_cache[page_content.language] = page_content
+            except AttributeError:
+                self.page_content_cache[page_content.language] = page_content
         language = func(self, language, fallback, force_reload)
         return language
 
     return inner
 
-
-pagemodel.Page._get_title_cache = _get_title_cache(
-    pagemodel.Page._get_title_cache
-)  # noqa: E305
+try:
+    pagemodel.Page._get_title_cache = _get_page_content_cache(
+        pagemodel.Page._get_title_cache
+    )  # noqa: E305
+except AttributeError:
+    pagemodel.Page._get_page_content_cache = _get_page_content_cache(
+        pagemodel.Page._get_page_content_cache
+    )  # noqa: E305
 
 
 def get_placeholders(func):
     def inner(self, language):
-        page_content = self.get_title_obj(language)
+        try:
+            page_content = self.get_title_obj(language)
+        except AttributeError:
+            page_content = self.get_content_obj(language)
         return Placeholder.objects.get_for_obj(page_content)
 
     return inner
@@ -61,8 +78,16 @@ def create_title(func):
 
 api.create_title = create_title(api.create_title)  # noqa: E305
 
-
-pagecontent_unique_together = tuple(
-    set(titlemodels.PageContent._meta.unique_together) - set((("language", "page"),))
-)
-titlemodels.PageContent._meta.unique_together = pagecontent_unique_together
+# Compat for change in django-cms
+try:
+    # Original v4 module
+    pagecontent_unique_together = tuple(
+        set(titlemodels.PageContent._meta.unique_together) - set((("language", "page"),))
+    )
+    titlemodels.PageContent._meta.unique_together = pagecontent_unique_together
+except NameError:
+    # Updated v4 attribute based on content models module name change
+    pagecontent_unique_together = tuple(
+        set(contentmodels.PageContent._meta.unique_together) - set((("language", "page"),))
+    )
+    contentmodels.PageContent._meta.unique_together = pagecontent_unique_together


### PR DESCRIPTION
This brings compatibility for the current cms v4 setup and the changes I've introduced with;

https://github.com/django-cms/django-cms/pull/7369

And I've included some basic pre-commit hooks for linters to help avoid issues at the point of github actions.