### PR TITLE
ci: Use patch api (django CMS 4.1+)

### DIFF
--- a/djangocms_versioning/admin.py
+++ b/djangocms_versioning/admin.py
@@ -40,7 +40,8 @@ from .versionables import _cms_extension
 try:
     from cms.utils.patching import patch_hook
 except ModuleNotFoundError:
-    patch_hook = lambda x: x
+    def patch_hook(func):
+        return func
 
 
 class VersioningChangeListMixin:

--- a/djangocms_versioning/admin.py
+++ b/djangocms_versioning/admin.py
@@ -37,6 +37,12 @@ from .models import Version
 from .versionables import _cms_extension
 
 
+try:
+    from cms.utils.patching import patch_hook
+except ModuleNotFoundError:
+    patch_hook = lambda x: x
+
+
 class VersioningChangeListMixin:
     """Mixin used for ChangeList classes of content models."""
 
@@ -498,6 +504,7 @@ class VersionAdmin(admin.ModelAdmin):
             {"archive_url": archive_url, "disabled": disabled},
         )
 
+    @patch_hook
     def _get_publish_link(self, obj, request):
         """Helper function to get the html link to the publish action
         """
@@ -622,6 +629,7 @@ class VersionAdmin(admin.ModelAdmin):
             {"discard_url": discard_url, "disabled": disabled},
         )
 
+    @patch_hook
     def get_state_actions(self):
         """Returns all action links as a list"""
         return [

--- a/djangocms_versioning/models.py
+++ b/djangocms_versioning/models.py
@@ -17,7 +17,8 @@ from .operations import send_post_version_operation, send_pre_version_operation
 try:
     from cms.utils.patching import patch_hook
 except ModuleNotFoundError:
-    patch_hook = lambda x: x
+    def patch_hook(func):
+        return func
 
 try:
     from djangocms_internalsearch.helpers import emit_content_change

--- a/djangocms_versioning/models.py
+++ b/djangocms_versioning/models.py
@@ -15,6 +15,11 @@ from .operations import send_post_version_operation, send_pre_version_operation
 
 
 try:
+    from cms.utils.patching import patch_hook
+except ModuleNotFoundError:
+    patch_hook = lambda x: x
+
+try:
     from djangocms_internalsearch.helpers import emit_content_change
 except ImportError:
     emit_content_change = None

--- a/djangocms_versioning/models.py
+++ b/djangocms_versioning/models.py
@@ -13,13 +13,6 @@ from . import constants, versionables
 from .conditions import Conditions, in_state
 from .operations import send_post_version_operation, send_pre_version_operation
 
-
-try:
-    from cms.utils.patching import patch_hook
-except ModuleNotFoundError:
-    def patch_hook(func):
-        return func
-
 try:
     from djangocms_internalsearch.helpers import emit_content_change
 except ImportError:

--- a/djangocms_versioning/models.py
+++ b/djangocms_versioning/models.py
@@ -13,6 +13,7 @@ from . import constants, versionables
 from .conditions import Conditions, in_state
 from .operations import send_post_version_operation, send_pre_version_operation
 
+
 try:
     from djangocms_internalsearch.helpers import emit_content_change
 except ImportError:

--- a/djangocms_versioning/monkeypatch/admin.py
+++ b/djangocms_versioning/monkeypatch/admin.py
@@ -12,6 +12,11 @@ from cms.utils.plugins import copy_plugins_to_placeholder
 from djangocms_versioning import versionables
 from djangocms_versioning.helpers import get_latest_admin_viewable_page_content
 
+try:
+    from cms.utils.patching import patch_cms
+except (ImportError, ModuleNotFoundError):
+    patch_cms = setattr
+
 
 def get_queryset(func):
     def inner(self, request):
@@ -32,16 +37,16 @@ def get_queryset(func):
     return inner
 
 
-admin.pageadmin.PageContentAdmin.get_queryset = get_queryset(
+patch_cms(admin.pageadmin.PageContentAdmin, "get_queryset",  get_queryset(
     admin.pageadmin.PageContentAdmin.get_queryset
-)
+))
 
 
 def get_admin_model_object_by_id(model_class, obj_id):
     return model_class._original_manager.get(pk=obj_id)
 
 
-helpers.get_admin_model_object_by_id = get_admin_model_object_by_id
+patch_cms(helpers, "get_admin_model_object_by_id", get_admin_model_object_by_id)
 
 
 # CAVEAT:

--- a/djangocms_versioning/monkeypatch/admin.py
+++ b/djangocms_versioning/monkeypatch/admin.py
@@ -12,6 +12,7 @@ from cms.utils.plugins import copy_plugins_to_placeholder
 from djangocms_versioning import versionables
 from djangocms_versioning.helpers import get_latest_admin_viewable_page_content
 
+
 try:
     from cms.utils.patching import patch_cms
 except ModuleNotFoundError:

--- a/djangocms_versioning/monkeypatch/admin.py
+++ b/djangocms_versioning/monkeypatch/admin.py
@@ -14,7 +14,7 @@ from djangocms_versioning.helpers import get_latest_admin_viewable_page_content
 
 try:
     from cms.utils.patching import patch_cms
-except (ImportError, ModuleNotFoundError):
+except ModuleNotFoundError:
     patch_cms = setattr
 
 
@@ -94,4 +94,4 @@ def copy_language(self, request, object_id):
     return HttpResponse("ok")
 
 
-admin.pageadmin.PageContentAdmin.copy_language = copy_language
+patch_cms(admin.pageadmin.PageContentAdmin, "copy_language", copy_language)

--- a/djangocms_versioning/monkeypatch/extensions.py
+++ b/djangocms_versioning/monkeypatch/extensions.py
@@ -11,6 +11,12 @@ from cms.utils.page_permissions import user_can_change_page
 from djangocms_versioning.handlers import _update_modified
 
 
+try:
+    from cms.utils.patching import patch_cms
+except ModuleNotFoundError:
+    patch_cms = setattr
+
+
 def _copy_title_extensions(self, source_page, target_page, language, clone=False):
     """
     djangocms-cms/extensions/admin.py, last changed in: divio/django-cms@2894ae8
@@ -38,7 +44,7 @@ def _copy_title_extensions(self, source_page, target_page, language, clone=False
                 instance.copy_to_public(target_title, language)
 
 
-ExtensionPool._copy_title_extensions = _copy_title_extensions
+patch_cms(ExtensionPool, "_copy_title_extensions", _copy_title_extensions)
 
 
 def _save_model(self, request, obj, form, change):
@@ -69,7 +75,7 @@ def _save_model(self, request, obj, form, change):
         _update_modified(title)
 
 
-TitleExtensionAdmin.save_model = _save_model
+patch_cms(TitleExtensionAdmin, "save_model", _save_model)
 
 
 @csrf_protect_m
@@ -98,4 +104,4 @@ def _add_view(self, request, form_url='', extra_context=None):
     return super(TitleExtensionAdmin, self).add_view(request, form_url, extra_context)
 
 
-TitleExtensionAdmin.add_view = _add_view
+patch_cms(TitleExtensionAdmin, "add_view", _add_view)

--- a/djangocms_versioning/monkeypatch/menu.py
+++ b/djangocms_versioning/monkeypatch/menu.py
@@ -3,6 +3,12 @@ from cms.utils.conf import get_cms_setting
 from menus.menu_pool import MenuRenderer
 
 
+try:
+    from cms.utils.patching import patch_cms
+except ModuleNotFoundError:
+    patch_cms = setattr
+
+
 def menu_renderer_cache_key(self):
     prefix = get_cms_setting("CACHE_PREFIX")
 
@@ -20,4 +26,4 @@ def menu_renderer_cache_key(self):
     return key
 
 
-MenuRenderer.cache_key = property(menu_renderer_cache_key)  # noqa: E305
+patch_cms(MenuRenderer, "cache_key", property(menu_renderer_cache_key))  # noqa: E305

--- a/djangocms_versioning/monkeypatch/page.py
+++ b/djangocms_versioning/monkeypatch/page.py
@@ -3,10 +3,15 @@ from django.contrib.auth import get_user_model
 
 from cms import api
 from cms.models import Placeholder, pagemodel, titlemodels
-from cms.utils.patching import patch_cms
 from cms.utils.permissions import _thread_locals
 
 from djangocms_versioning.models import Version
+
+
+try:
+    from cms.utils.patching import patch_cms
+except ModuleNotFoundError:
+    patch_cms = setattr
 
 
 User = get_user_model()

--- a/djangocms_versioning/monkeypatch/page.py
+++ b/djangocms_versioning/monkeypatch/page.py
@@ -1,9 +1,9 @@
-from cms.utils.patching import patch_cms
 from django.apps import apps
 from django.contrib.auth import get_user_model
 
 from cms import api
 from cms.models import Placeholder, pagemodel, titlemodels
+from cms.utils.patching import patch_cms
 from cms.utils.permissions import _thread_locals
 
 from djangocms_versioning.models import Version

--- a/djangocms_versioning/monkeypatch/templatetags.py
+++ b/djangocms_versioning/monkeypatch/templatetags.py
@@ -1,4 +1,5 @@
 from cms.templatetags import cms_admin
+from cms.utils.patching import patch_cms
 from cms.utils.urlutils import admin_reverse
 
 
@@ -18,4 +19,4 @@ def get_admin_url_for_language(page, language):
     return admin_reverse("cms_pagecontent_change", args=[page_content.pk])
 
 
-cms_admin.get_admin_url_for_language = get_admin_url_for_language  # noqa: E305
+patch_cms(cms_admin, "get_admin_url_for_language", get_admin_url_for_language)  # noqa: E305

--- a/djangocms_versioning/monkeypatch/templatetags.py
+++ b/djangocms_versioning/monkeypatch/templatetags.py
@@ -1,6 +1,11 @@
 from cms.templatetags import cms_admin
-from cms.utils.patching import patch_cms
 from cms.utils.urlutils import admin_reverse
+
+
+try:
+    from cms.utils.patching import patch_cms
+except ModuleNotFoundError:
+    patch_cms = setattr
 
 
 @cms_admin.register.simple_tag(takes_context=False)

--- a/djangocms_versioning/monkeypatch/toolbar.py
+++ b/djangocms_versioning/monkeypatch/toolbar.py
@@ -1,6 +1,7 @@
 from functools import lru_cache
 
 from cms.toolbar import toolbar
+from cms.utils.patching import patch_cms
 
 from djangocms_versioning.plugin_rendering import (
     VersionContentRenderer,
@@ -13,7 +14,7 @@ def content_renderer(self):
     return VersionContentRenderer(request=self.request)
 
 
-toolbar.CMSToolbar.content_renderer = property(content_renderer)  # noqa: E305
+patch_cms(toolbar.CMSToolbar, "content_renderer", property(content_renderer))  # noqa: E305
 
 
 @lru_cache(16)
@@ -21,6 +22,6 @@ def structure_renderer(self):
     return VersionStructureRenderer(request=self.request)
 
 
-toolbar.CMSToolbar.structure_renderer = property(
+patch_cms(toolbar.CMSToolbar, "structure_renderer", property(
     structure_renderer
-)  # noqa: E305
+))  # noqa: E305

--- a/djangocms_versioning/monkeypatch/toolbar.py
+++ b/djangocms_versioning/monkeypatch/toolbar.py
@@ -1,12 +1,17 @@
 from functools import lru_cache
 
 from cms.toolbar import toolbar
-from cms.utils.patching import patch_cms
 
 from djangocms_versioning.plugin_rendering import (
     VersionContentRenderer,
     VersionStructureRenderer,
 )
+
+
+try:
+    from cms.utils.patching import patch_cms
+except ModuleNotFoundError:
+    patch_cms = setattr
 
 
 @lru_cache(16)

--- a/djangocms_versioning/monkeypatch/wizard.py
+++ b/djangocms_versioning/monkeypatch/wizard.py
@@ -1,3 +1,4 @@
+from cms.utils.patching import patch_cms
 from django.apps import apps
 
 from cms.cms_wizards import CMSPageWizard, CMSSubPageWizard
@@ -20,7 +21,7 @@ def get_wizard_success_url(self, obj, **kwargs):  # noqa: E302
     return original_get_wizard_success_url(self, obj, **kwargs)
 
 
-Wizard.get_success_url = get_wizard_success_url  # noqa: E305
+patch_cms(Wizard, "get_success_url", get_wizard_success_url)
 
 
 def get_page_wizard_success_url(self, obj, **kwargs):
@@ -35,5 +36,5 @@ def get_page_wizard_success_url(self, obj, **kwargs):
     return get_wizard_success_url(self, page_content, **kwargs)
 
 
-CMSPageWizard.get_success_url = get_page_wizard_success_url  # noqa: E305
-CMSSubPageWizard.get_success_url = get_page_wizard_success_url
+patch_cms(CMSPageWizard, "get_success_url", get_page_wizard_success_url)
+patch_cms(CMSSubPageWizard, "get_success_url", get_page_wizard_success_url)

--- a/djangocms_versioning/monkeypatch/wizard.py
+++ b/djangocms_versioning/monkeypatch/wizard.py
@@ -1,9 +1,9 @@
-from cms.utils.patching import patch_cms
 from django.apps import apps
 
 from cms.cms_wizards import CMSPageWizard, CMSSubPageWizard
 from cms.toolbar.utils import get_object_preview_url
 from cms.utils.helpers import is_editable_model
+from cms.utils.patching import patch_cms
 from cms.wizards.wizard_base import Wizard
 
 from djangocms_versioning.constants import DRAFT

--- a/djangocms_versioning/monkeypatch/wizard.py
+++ b/djangocms_versioning/monkeypatch/wizard.py
@@ -3,10 +3,15 @@ from django.apps import apps
 from cms.cms_wizards import CMSPageWizard, CMSSubPageWizard
 from cms.toolbar.utils import get_object_preview_url
 from cms.utils.helpers import is_editable_model
-from cms.utils.patching import patch_cms
 from cms.wizards.wizard_base import Wizard
 
 from djangocms_versioning.constants import DRAFT
+
+
+try:
+    from cms.utils.patching import patch_cms
+except ModuleNotFoundError:
+    patch_cms = setattr
 
 
 original_get_wizard_success_url = Wizard.get_success_url


### PR DESCRIPTION
## Description

This PR implements the patching API for django CMS v4 (https://github.com/django-cms/django-cms/pull/7439) for djangocms-versioning in a backward compatible way. 

The patching API requires functions, methods, or properties that are patched to be marked by the `@patch_hook` decorator. Trying to patch functions, methods, or properties that are no marked will raise an `ImproperlyConfigured` exception. 

This is a precaution to ensure developers of the core are aware of patch hooks and to prevent injection of side-effects in the future as far as possible.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* https://github.com/django-cms/django-cms/pull/7439

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
