### PR TITLE
fix: Copy language menu

### DIFF
--- a/djangocms_versioning/cms_toolbars.py
+++ b/djangocms_versioning/cms_toolbars.py
@@ -292,7 +292,6 @@ class VersioningPageToolbar(PageToolbar):
                         )
 
 
-
 def replace_toolbar(old, new):
     """Replace `old` toolbar class with `new` class,
     while keeping its position in toolbar_pool.

--- a/djangocms_versioning/cms_toolbars.py
+++ b/djangocms_versioning/cms_toolbars.py
@@ -217,7 +217,7 @@ class VersioningPageToolbar(PageToolbar):
                 language_menu.remove_item(item=_item)
 
             for code, name in get_language_tuple(self.current_site.pk):
-                # Get the pagw content, it could be draft too!
+                # Get the page content, it could be draft too!
                 page_content = self.get_page_content(language=code)
                 if page_content:
                     url = get_object_preview_url(page_content, code)
@@ -278,12 +278,19 @@ class VersioningPageToolbar(PageToolbar):
                 for code, name in copy:
                     # Get the Draft or Published PageContent.
                     page_content = self.get_page_content(language=code)
-                    page_copy_url = admin_reverse('cms_pagecontent_copy_language', args=(page_content.pk,))
-                    copy_plugins_menu.add_ajax_item(
-                        title % name, action=page_copy_url,
-                        data={'source_language': code, 'target_language': self.current_lang},
-                        question=question % name, on_success=self.toolbar.REFRESH_PAGE
-                    )
+                    if page_content:
+                        page_copy_url = admin_reverse('cms_pagecontent_copy_language', args=(page_content.pk,))
+                        copy_plugins_menu.add_ajax_item(
+                            title % name, action=page_copy_url,
+                            data={'source_language': code, 'target_language': self.current_lang},
+                            question=question % name, on_success=self.toolbar.REFRESH_PAGE
+                        )
+                    else:
+                        copy_plugins_menu.add_ajax_item(
+                            title % name, action="#",
+                            disabled=True,
+                        )
+
 
 
 def replace_toolbar(old, new):

--- a/djangocms_versioning/helpers.py
+++ b/djangocms_versioning/helpers.py
@@ -8,7 +8,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.db.models.sql.where import WhereNode
 from django.urls import reverse
 
-from cms.models import PageContent
+from cms.models import EmptyPageContent, PageContent
 from cms.toolbar.utils import get_object_edit_url, get_object_preview_url
 from cms.utils.helpers import is_editable_model
 from cms.utils.urlutils import add_url_parameters, admin_reverse
@@ -304,8 +304,8 @@ def get_latest_admin_viewable_page_content(page, language):
     return PageContent._original_manager.filter(
         page=page, language=language, versions__state__in=[DRAFT, PUBLISHED]
     ).order_by(
-        "versions__state"
-    ).first()
+        "versions__state"  # "draft" < "published"
+    ).first() or EmptyPageContent(language)
 
 
 def proxy_model(obj, content_model):


### PR DESCRIPTION
## Description

djangocms-versioning patches the toolbar and rebuilds the copy language menu to copy from the latest (potentially draft) version of the other language.

If **no version** of another language existed the toolbar threw an exception when trying to get the link for the action. With the toolbar raising an exception the page content becomes uneditable.

This PR greys out languages which do not have any published or draft version available to copy a language from.


## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
