### PR TITLE
fix: test requirements after removing the patching pattern

### DIFF
--- a/tests/requirements/requirements_base.txt
+++ b/tests/requirements/requirements_base.txt
@@ -13,6 +13,6 @@ python-dateutil
 mysqlclient==2.0.3
 psycopg2
 
+djangocms-text-ckeditor=>5.1.2
 # Unreleased django-cms 4.0 compatible packages
-https://github.com/fsbraun/django-cms/tarball/fix/remove-patching#egg=django-cms
-https://github.com/django-cms/djangocms-text-ckeditor/tarball/support/4.0.x#egg=djangocms-text-ckeditor
+https://github.com/django-cms/django-cms/tarball/develop-4#egg=django-cms

--- a/tests/requirements/requirements_base.txt
+++ b/tests/requirements/requirements_base.txt
@@ -13,6 +13,6 @@ python-dateutil
 mysqlclient==2.0.3
 psycopg2
 
-djangocms-text-ckeditor=>5.1.2
+djangocms-text-ckeditor>=5.1.2
 # Unreleased django-cms 4.0 compatible packages
 https://github.com/django-cms/django-cms/tarball/develop-4#egg=django-cms


### PR DESCRIPTION
## Description

After merging #300 the test requirements need to be fixed against the `django-cms/develop-4` branch (which now also contains the changes needed for #300)

Additionally we can now use the latest released djangocms-text-ckeditor since as of 5.1.2 it supports django CMS 4

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #300
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
