### PR TITLE
Some fixed strings are now translatable

### DIFF
--- a/djangocms_versioning/constants.py
+++ b/djangocms_versioning/constants.py
@@ -1,13 +1,17 @@
+from django.utils.translation import gettext_lazy as _
+
+
 """Version states"""
 ARCHIVED = "archived"
 DRAFT = "draft"
 PUBLISHED = "published"
 UNPUBLISHED = "unpublished"
+
 VERSION_STATES = (
-    (DRAFT, "Draft"),
-    (PUBLISHED, "Published"),
-    (UNPUBLISHED, "Unpublished"),
-    (ARCHIVED, "Archived"),
+    (DRAFT, _("Draft")),
+    (PUBLISHED, _("Published")),
+    (UNPUBLISHED, _("Unpublished")),
+    (ARCHIVED, _("Archived")),
 )
 """Version operation states"""
 OPERATION_ARCHIVE = "operation_archive"

--- a/djangocms_versioning/locale/de/LC_MESSAGES/django.po
+++ b/djangocms_versioning/locale/de/LC_MESSAGES/django.po
@@ -2,23 +2,23 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Fabian Braun <fsbraun@gmx.de>, 2023
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-11 05:51+0100\n"
+"POT-Creation-Date: 2023-01-22 19:30+0100\n"
 "PO-Revision-Date: 2023-01-10 15:29+0000\n"
 "Last-Translator: Fabian Braun <fsbraun@gmx.de>, 2023\n"
 "Language-Team: German (https://www.transifex.com/divio/teams/58664/de/)\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: admin.py:161
@@ -29,7 +29,7 @@ msgstr "Status"
 msgid "Author"
 msgstr "Autor"
 
-#: admin.py:184
+#: admin.py:184 models.py:70
 msgid "Modified"
 msgstr "Geändert"
 
@@ -104,7 +104,7 @@ msgstr "django CMS Versioning"
 msgid "No available title"
 msgstr "Kein Titel verfügbar"
 
-#: cms_config.py:239 indicators.py:25
+#: cms_config.py:239 constants.py:13 indicators.py:25
 msgid "Unpublished"
 msgstr "Veröffentlichung aufgehoben"
 
@@ -175,21 +175,21 @@ msgstr "Sind Sie sicher, dass sie alle Plugins von %s kopieren wollen?"
 msgid "No other language available"
 msgstr "Keine andere Sprache verfügbar"
 
-#: indicators.py:22
+#: constants.py:11 indicators.py:24
+msgid "Draft"
+msgstr "Entwurf"
+
+#: constants.py:12 indicators.py:22
 msgid "Published"
 msgstr "Veröffentlicht"
+
+#: constants.py:14 indicators.py:26
+msgid "Archived"
+msgstr "Archiviert"
 
 #: indicators.py:23
 msgid "Changed"
 msgstr "Verändert"
-
-#: indicators.py:24
-msgid "Draft"
-msgstr "Entwurf"
-
-#: indicators.py:26
-msgid "Archived"
-msgstr "Archiviert"
 
 #: indicators.py:27
 msgid "Empty"
@@ -223,6 +223,12 @@ msgstr "Entwurf mit Veröffentlichung vergleichen..."
 #: indicators.py:90
 msgid "Manage Versions..."
 msgstr "Versionen verwalten..."
+
+#: models.py:69
+#, fuzzy
+#| msgid "Create new draft"
+msgid "Created"
+msgstr "Neuen Entwurf erstellen"
 
 #: models.py:72
 msgid "author"

--- a/djangocms_versioning/locale/en/LC_MESSAGES/django.po
+++ b/djangocms_versioning/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-11 05:51+0100\n"
+"POT-Creation-Date: 2023-01-22 19:30+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -26,7 +26,7 @@ msgstr ""
 msgid "Author"
 msgstr ""
 
-#: admin.py:184
+#: admin.py:184 models.py:70
 msgid "Modified"
 msgstr ""
 
@@ -101,7 +101,7 @@ msgstr ""
 msgid "No available title"
 msgstr ""
 
-#: cms_config.py:239 indicators.py:25
+#: cms_config.py:239 constants.py:13 indicators.py:25
 msgid "Unpublished"
 msgstr ""
 
@@ -172,20 +172,20 @@ msgstr ""
 msgid "No other language available"
 msgstr ""
 
-#: indicators.py:22
+#: constants.py:11 indicators.py:24
+msgid "Draft"
+msgstr ""
+
+#: constants.py:12 indicators.py:22
 msgid "Published"
+msgstr ""
+
+#: constants.py:14 indicators.py:26
+msgid "Archived"
 msgstr ""
 
 #: indicators.py:23
 msgid "Changed"
-msgstr ""
-
-#: indicators.py:24
-msgid "Draft"
-msgstr ""
-
-#: indicators.py:26
-msgid "Archived"
 msgstr ""
 
 #: indicators.py:27
@@ -219,6 +219,10 @@ msgstr ""
 
 #: indicators.py:90
 msgid "Manage Versions..."
+msgstr ""
+
+#: models.py:69
+msgid "Created"
 msgstr ""
 
 #: models.py:72

--- a/djangocms_versioning/locale/fr/LC_MESSAGES/django.po
+++ b/djangocms_versioning/locale/fr/LC_MESSAGES/django.po
@@ -2,24 +2,25 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # François Palmier <fp@kapt.mobi>, 2023
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-11 05:51+0100\n"
+"POT-Creation-Date: 2023-01-22 19:30+0100\n"
 "PO-Revision-Date: 2023-01-10 15:29+0000\n"
 "Last-Translator: François Palmier <fp@kapt.mobi>, 2023\n"
 "Language-Team: French (https://www.transifex.com/divio/teams/58664/fr/)\n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: fr\n"
-"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % "
+"1000000 == 0 ? 1 : 2;\n"
 
 #: admin.py:161
 msgid "State"
@@ -29,7 +30,7 @@ msgstr "État"
 msgid "Author"
 msgstr "Auteur"
 
-#: admin.py:184
+#: admin.py:184 models.py:70
 msgid "Modified"
 msgstr "Modifié"
 
@@ -104,7 +105,7 @@ msgstr "django CMS Versioning"
 msgid "No available title"
 msgstr "Aucun titre disponible"
 
-#: cms_config.py:239 indicators.py:25
+#: cms_config.py:239 constants.py:13 indicators.py:25
 msgid "Unpublished"
 msgstr "Non publié"
 
@@ -175,21 +176,21 @@ msgstr "Êtes-vous sûr de vouloir copier tous les plugins de %s?"
 msgid "No other language available"
 msgstr "Aucune autre langue disponible"
 
-#: indicators.py:22
+#: constants.py:11 indicators.py:24
+msgid "Draft"
+msgstr "Brouillon"
+
+#: constants.py:12 indicators.py:22
 msgid "Published"
 msgstr "Publié"
+
+#: constants.py:14 indicators.py:26
+msgid "Archived"
+msgstr "Archivé"
 
 #: indicators.py:23
 msgid "Changed"
 msgstr "Modifié"
-
-#: indicators.py:24
-msgid "Draft"
-msgstr "Brouillon"
-
-#: indicators.py:26
-msgid "Archived"
-msgstr "Archivé"
 
 #: indicators.py:27
 msgid "Empty"
@@ -223,6 +224,12 @@ msgstr "Comparer le brouillon à la version publiée..."
 #: indicators.py:90
 msgid "Manage Versions..."
 msgstr "Gérer les versions..."
+
+#: models.py:69
+#, fuzzy
+#| msgid "Create new draft"
+msgid "Created"
+msgstr "Créer un brouillon"
 
 #: models.py:72
 msgid "author"

--- a/djangocms_versioning/locale/nl/LC_MESSAGES/django.po
+++ b/djangocms_versioning/locale/nl/LC_MESSAGES/django.po
@@ -2,23 +2,23 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Stefan van den Eertwegh <stefan@corebyte.nl>, 2023
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-11 05:51+0100\n"
+"POT-Creation-Date: 2023-01-22 19:30+0100\n"
 "PO-Revision-Date: 2023-01-10 15:29+0000\n"
 "Last-Translator: Stefan van den Eertwegh <stefan@corebyte.nl>, 2023\n"
 "Language-Team: Dutch (https://www.transifex.com/divio/teams/58664/nl/)\n"
+"Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: nl\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: admin.py:161
@@ -29,7 +29,7 @@ msgstr "Status"
 msgid "Author"
 msgstr "Auteur"
 
-#: admin.py:184
+#: admin.py:184 models.py:70
 msgid "Modified"
 msgstr "Gewijzigd"
 
@@ -104,7 +104,7 @@ msgstr "django CMS Versionering"
 msgid "No available title"
 msgstr "Geen beschikbare titel"
 
-#: cms_config.py:239 indicators.py:25
+#: cms_config.py:239 constants.py:13 indicators.py:25
 msgid "Unpublished"
 msgstr "Gedepubliseerd"
 
@@ -175,21 +175,21 @@ msgstr "Ben je er zeker van om alle plugins te kopiëren van %s?"
 msgid "No other language available"
 msgstr "Geen andere taal beschikbaar"
 
-#: indicators.py:22
+#: constants.py:11 indicators.py:24
+msgid "Draft"
+msgstr "Concept"
+
+#: constants.py:12 indicators.py:22
 msgid "Published"
 msgstr "Gepubliseerd"
+
+#: constants.py:14 indicators.py:26
+msgid "Archived"
+msgstr "Archiveerd"
 
 #: indicators.py:23
 msgid "Changed"
 msgstr "Gewijzigd"
-
-#: indicators.py:24
-msgid "Draft"
-msgstr "Concept"
-
-#: indicators.py:26
-msgid "Archived"
-msgstr "Archiveerd"
 
 #: indicators.py:27
 msgid "Empty"
@@ -223,6 +223,12 @@ msgstr "Vergelijk Concept naar Publiceren..."
 #: indicators.py:90
 msgid "Manage Versions..."
 msgstr "Beheer versies..."
+
+#: models.py:69
+#, fuzzy
+#| msgid "Create new draft"
+msgid "Created"
+msgstr "Maakt een nieuw concept"
 
 #: models.py:72
 msgid "author"

--- a/djangocms_versioning/locale/sq/LC_MESSAGES/django.po
+++ b/djangocms_versioning/locale/sq/LC_MESSAGES/django.po
@@ -2,23 +2,23 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Besnik Bleta <besnik@programeshqip.org>, 2023
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-11 05:51+0100\n"
+"POT-Creation-Date: 2023-01-22 19:30+0100\n"
 "PO-Revision-Date: 2023-01-10 15:29+0000\n"
 "Last-Translator: Besnik Bleta <besnik@programeshqip.org>, 2023\n"
 "Language-Team: Albanian (https://www.transifex.com/divio/teams/58664/sq/)\n"
+"Language: sq\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: sq\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: admin.py:161
@@ -29,7 +29,7 @@ msgstr "Gjendje"
 msgid "Author"
 msgstr "Autor"
 
-#: admin.py:184
+#: admin.py:184 models.py:70
 msgid "Modified"
 msgstr "E ndryshuar"
 
@@ -104,7 +104,7 @@ msgstr "Versione në django CMS"
 msgid "No available title"
 msgstr "S’ka titull"
 
-#: cms_config.py:239 indicators.py:25
+#: cms_config.py:239 constants.py:13 indicators.py:25
 msgid "Unpublished"
 msgstr "I pabotuar"
 
@@ -175,21 +175,21 @@ msgstr "Jeni i sigurt se doni të kopjohen krejt shtojcat prej %s?"
 msgid "No other language available"
 msgstr "S’ka gjuhë të tjera"
 
-#: indicators.py:22
+#: constants.py:11 indicators.py:24
+msgid "Draft"
+msgstr "Skicë"
+
+#: constants.py:12 indicators.py:22
 msgid "Published"
 msgstr "I botuar"
+
+#: constants.py:14 indicators.py:26
+msgid "Archived"
+msgstr "I arkivuar"
 
 #: indicators.py:23
 msgid "Changed"
 msgstr "I ndryshur"
-
-#: indicators.py:24
-msgid "Draft"
-msgstr "Skicë"
-
-#: indicators.py:26
-msgid "Archived"
-msgstr "I arkivuar"
 
 #: indicators.py:27
 msgid "Empty"
@@ -223,6 +223,12 @@ msgstr "Krahaso Skicë me të Pabotuar…"
 #: indicators.py:90
 msgid "Manage Versions..."
 msgstr "Administroni Versione…"
+
+#: models.py:69
+#, fuzzy
+#| msgid "Create new draft"
+msgid "Created"
+msgstr "Krijoni një skicë të re"
 
 #: models.py:72
 msgid "author"

--- a/djangocms_versioning/models.py
+++ b/djangocms_versioning/models.py
@@ -66,8 +66,8 @@ class VersionQuerySet(models.QuerySet):
 
 class Version(models.Model):
 
-    created = models.DateTimeField(auto_now_add=True)
-    modified = models.DateTimeField(default=timezone.now)
+    created = models.DateTimeField(auto_now_add=True, verbose_name=_("Created"))
+    modified = models.DateTimeField(default=timezone.now, verbose_name=_("Modified"))
     created_by = models.ForeignKey(
         settings.AUTH_USER_MODEL, on_delete=models.PROTECT, verbose_name=_("author")
     )


### PR DESCRIPTION
## Description

constants.py = 4 fixed strings which dit not parsed through _()
models.py = 2 date fields which did not had verbose_name


* [ ] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
