### PR TITLE
feat: Add preview button to view published mode

### DIFF
--- a/djangocms_versioning/cms_toolbars.py
+++ b/djangocms_versioning/cms_toolbars.py
@@ -193,7 +193,7 @@ class VersioningToolbar(PlaceholderToolbar):
     def _add_view_published_button(self):
         """Helper method to add a publish button to the toolbar
         """
-        # Check if object is registered with versioning otherwise dont add
+        # Check if object is registered with versioning otherwise don't add
         if not self._is_versioned():
             return
 
@@ -213,8 +213,21 @@ class VersioningToolbar(PlaceholderToolbar):
             )
             self.toolbar.add_item(item)
 
+    def _add_preview_button(self):
+        """Helper method to add a preview button to the toolbar when not in preview mode"""
+        # Check if object is registered with versioning otherwise don't add
+        if not self._is_versioned():
+            return
+
+        if not self.toolbar.preview_mode_active and not self.toolbar.edit_mode_active:
+            # Any mode not preview mode can have a preview button
+            # Exclude edit mode, however, since the django CMS core already ads the preview button for edit mode
+            self.add_preview_button()
+
+
     def post_template_populate(self):
         super(VersioningToolbar, self).post_template_populate()
+        self._add_preview_button()
         self._add_view_published_button()
         self._add_revert_button()
         self._add_publish_button()
@@ -256,7 +269,7 @@ class VersioningPageToolbar(PageToolbar):
                 language_menu.remove_item(item=_item)
 
             for code, name in get_language_tuple(self.current_site.pk):
-                # Get the pagw content, it could be draft too!
+                # Get the page content, it could be draft too!
                 page_content = self.get_page_content(language=code)
                 if page_content:
                     url = get_object_preview_url(page_content, code)

--- a/djangocms_versioning/cms_toolbars.py
+++ b/djangocms_versioning/cms_toolbars.py
@@ -224,7 +224,6 @@ class VersioningToolbar(PlaceholderToolbar):
             # Exclude edit mode, however, since the django CMS core already ads the preview button for edit mode
             self.add_preview_button()
 
-
     def post_template_populate(self):
         super(VersioningToolbar, self).post_template_populate()
         self._add_preview_button()


### PR DESCRIPTION
## Description

Currently, there is no way to use the toolbar to get from viewing a published version of a page (or other object) back to its preview. The only option available is "Edit" which will create a new draft or go to an existing draft.

With this PR the view published mode will have an additional button to get (back) to the preview.

I expect it to create more transparency on the modes available with djangocms-verisoning

* Edit mode (as with the core): Visible to staff only
* Preview mode (incldeing draft content): Visible to staff only
* Published mode (only published content): Visible to the outside

Also there are use cases where published versions and the preview of a public version need to be compared:
* The **published version only contains public versioned items** 
* The **preview of a public version** contains **draft versions of, e.g., versioned alias objects**

![preview](https://user-images.githubusercontent.com/16904477/214282785-d674665f-ff3e-4d88-a49d-4ec96efa38dd.gif)


## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
