### PR TITLE
feat: Huge performance improvement for admin_manager

### DIFF
--- a/djangocms_versioning/managers.py
+++ b/djangocms_versioning/managers.py
@@ -1,6 +1,5 @@
 import warnings
 from copy import copy
-from itertools import groupby
 
 from django.contrib.auth import get_user_model
 from django.db import models

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -38,6 +38,7 @@ class ExtensionTestCase(CMSTestCase):
             translations=False,
             permissions=False,
             extensions=False,
+            user=self.get_superuser(),
         )
         new_page_content = PageContentFactory(page=self.new_page, language='de')
         self.new_page.page_content_cache[de_pagecontent.language] = new_page_content


### PR DESCRIPTION
## Description

The `admin_manager` of a versioned model provided access to `current_content_iterator` which allowed to "filter" out all current versions of the model: Either draft or published (if there is no draft). This API had the drawback that the result was not a queryset but an iterator (since the grouping was done in python).

This method is now replaced by `current_content()` which is a filter that returns a queryset that only contains the current verison of the objects. Not only is it more convenient to have a qs returned, the number of database hits reduces from O(n) with n being the number of objects to 1.

`current_content_iterator` is kept to ensure compatibility with django CMS v4.1.0rc1

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
