### PR TITLE
fix "View Published" and version preview urls for non main language 

### DIFF
--- a/djangocms_versioning/admin.py
+++ b/djangocms_versioning/admin.py
@@ -17,7 +17,7 @@ from django.template.response import TemplateResponse
 from django.urls import Resolver404, re_path, resolve, reverse
 from django.utils.encoding import force_str
 from django.utils.html import format_html, format_html_join
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _, override, get_language
 
 from cms.models import PageContent
 from cms.utils import get_language_from_request
@@ -563,13 +563,15 @@ class VersionAdmin(admin.ModelAdmin):
     def content_link(self, obj):
         """Display html for the content preview url"""
         content = obj.content
-        url = get_preview_url(content)
+        language = content.language if hasattr(content, 'language') else get_language()
+        with override(language):
+            url = get_preview_url(content)
 
-        return format_html(
-            '<a target="_top" class="js-versioning-close-sideframe" href="{url}">{label}</a>',
-            url=url,
-            label=content,
-        )
+            return format_html(
+                '<a target="_top" class="js-versioning-close-sideframe" href="{url}">{label}</a>',
+                url=url,
+                label=content,
+            )
 
     content_link.short_description = _("Content")
     content_link.admin_order_field = "content"

--- a/djangocms_versioning/cms_toolbars.py
+++ b/djangocms_versioning/cms_toolbars.py
@@ -7,7 +7,7 @@ from django.contrib.auth import get_permission_codename
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 from django.utils.http import urlencode
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _, override
 
 from cms.cms_toolbars import (
     ADD_PAGE_LANGUAGE_BREAK,
@@ -220,16 +220,17 @@ class VersioningToolbar(PlaceholderToolbar):
         if not published_version:
             return
 
-        url = published_version.get_absolute_url() if hasattr(published_version, 'get_absolute_url') else None
-        if url and (self.toolbar.edit_mode_active or self.toolbar.preview_mode_active):
-            item = ButtonList(side=self.toolbar.RIGHT)
-            item.add_button(
-                _("View Published"),
-                url=url,
-                disabled=False,
-                extra_classes=['cms-btn', 'cms-btn-switch-save'],
-            )
-            self.toolbar.add_item(item)
+        with override(self.current_lang):
+            url = published_version.get_absolute_url() if hasattr(published_version, 'get_absolute_url') else None
+            if url and (self.toolbar.edit_mode_active or self.toolbar.preview_mode_active):
+                item = ButtonList(side=self.toolbar.RIGHT)
+                item.add_button(
+                    _("View Published"),
+                    url=url,
+                    disabled=False,
+                    extra_classes=['cms-btn', 'cms-btn-switch-save'],
+                )
+                self.toolbar.add_item(item)
 
     def _add_preview_button(self):
         """Helper method to add a preview button to the toolbar when not in preview mode"""


### PR DESCRIPTION
## Description

When I click 'View published' on a non "en-gb" version of a page I'm taken to the "en-gb" version. 
Also when I click to content link in version list for a non "en-gb" version  I'm taken to the "en-gb" version. 

## Related resources


## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
