### PR TITLE
Fix 342 hook to copy relations

### DIFF
--- a/djangocms_versioning/cms_config.py
+++ b/djangocms_versioning/cms_config.py
@@ -238,7 +238,9 @@ def copy_page_content(original_content):
                 if field.name not in (PageContent._meta.pk.name, "extended_object")
             }
             extension_fields["extended_object"] = new_content
-            field.related_model.objects.create(**extension_fields)
+            new_extension = field.related_model.objects.create(**extension_fields)
+            if callable(getattr(new_extension, 'copy_relations', None)):
+                new_extension.copy_relations(extension)
 
     return new_content
 

--- a/tests/test_cms_config.py
+++ b/tests/test_cms_config.py
@@ -110,7 +110,7 @@ class PageContentVersioningBehaviourTestCase(CMSTestCase):
         new_title = "new slug here"
         data = {
             "title": self.content.title,
-            "slug": new_title
+            "slug": slugify(new_title),
         }
 
         request = req_factory.get("/?language=en")


### PR DESCRIPTION
## Description

Details on this can be found in #342.

Running tests on this PR will fail, because the signature of the CMS's [PageContentExtension.copy_relations()](https://github.com/django-cms/django-cms/blob/5caf8d5c2a8e63f523fa9b43fb074adf321a57dd/cms/extensions/models.py#L23) does not fit here.

This has to be changed first in the `devel_4` branch of django-cms itself.

## Related resources

This fixes #342

## Checklist

* [x] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.

Unit tests are pending. See above for the reason.