### PR TITLE
fix: PageContent extension's `copy_relations` method not called

### DIFF
--- a/djangocms_versioning/cms_config.py
+++ b/djangocms_versioning/cms_config.py
@@ -1,6 +1,7 @@
 import collections
 
 from cms.app_base import CMSAppConfig, CMSAppExtension
+from cms.extensions.models import BaseExtension
 from cms.models import PageContent, Placeholder
 from cms.utils import get_language_from_request
 from cms.utils.i18n import get_language_list, get_language_tuple
@@ -228,17 +229,12 @@ def copy_page_content(original_content):
         new_placeholders.append(new_placeholder)
     new_content.placeholders.add(*new_placeholders)
 
-    # If pagecontent has an associated title or page extension, also copy this!
+    # If pagecontent has an associated content or page extension, also copy this!
     for field in PageContent._meta.related_objects:
         if hasattr(original_content, field.name):
             extension = getattr(original_content, field.name)
-            extension_fields = {
-                field.name: getattr(extension, field.name)
-                for field in extension._meta.fields
-                if field.name not in (PageContent._meta.pk.name, "extended_object")
-            }
-            extension_fields["extended_object"] = new_content
-            field.related_model.objects.create(**extension_fields)
+            if isinstance(extension, BaseExtension):
+                extension.copy(new_content, new_content.language)
 
     return new_content
 
@@ -262,7 +258,6 @@ def on_page_content_publish(version):
         page._remove_title_root_path()
     page._update_url_path_recursive(language)
     page.clear_cache(menu=True)
-
 
 def on_page_content_unpublish(version):
     """Url path and cache operations to do when a PageContent obj is unpublished"""

--- a/tests/test_cms_config.py
+++ b/tests/test_cms_config.py
@@ -107,7 +107,7 @@ class PageContentVersioningBehaviourTestCase(CMSTestCase):
 
     def test_changing_slug_changes_page_url(self):
         """Using change form to change title / slug updates path?"""
-        new_title = "new slug here"
+        new_title = "new-slug-here"
         data = {
             "title": self.content.title,
             "slug": new_title
@@ -119,6 +119,7 @@ class PageContentVersioningBehaviourTestCase(CMSTestCase):
         form = ChangePageForm(data, instance=self.content)
         form._request = request
         form._site = self.site
+        form.is_valid()
         self.assertEqual(form.is_valid(), True)
 
         form.save()

--- a/tests/test_cms_config.py
+++ b/tests/test_cms_config.py
@@ -119,7 +119,6 @@ class PageContentVersioningBehaviourTestCase(CMSTestCase):
         form = ChangePageForm(data, instance=self.content)
         form._request = request
         form._site = self.site
-        form.is_valid()
         self.assertEqual(form.is_valid(), True)
 
         form.save()

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from cms.extensions.extension_pool import ExtensionPool
 from cms.test_utils.testcases import CMSTestCase
 from cms.utils.urlutils import admin_reverse
@@ -63,9 +65,12 @@ class ExtensionTestCase(CMSTestCase):
         page_content = self.version.content
         poll_extension = PollTitleExtensionFactory(extended_object=page_content)
         poll_extension.votes = 5
+        poll_extension.save()
 
-        new_pagecontent = copy_page_content(page_content)
+        with patch("cms.extensions.PageContentExtension.copy_relations") as mock:
+            new_pagecontent = copy_page_content(page_content)
 
+        mock.assert_called_once()
         self.assertNotEqual(new_pagecontent.pollpagecontentextension, poll_extension)
         self.assertEqual(page_content.pollpagecontentextension.pk, poll_extension.pk)
         self.assertNotEqual(page_content.pollpagecontentextension.pk, new_pagecontent.pollpagecontentextension.pk)
@@ -89,6 +94,7 @@ class ExtensionTestCase(CMSTestCase):
         page_content = self.version.content
         poll_extension = PollTitleExtensionFactory(extended_object=page_content)
         poll_extension.votes = 5
+        poll_extension.save()  # Needs to be in the db for copy method of core to work
         title_extension = TestTitleExtensionFactory(extended_object=page_content)
 
         new_pagecontent = copy_page_content(page_content)


### PR DESCRIPTION
## Description

This PR fixes #342 and is based on #343. 

CMS extensions have a [`copy` method](https://github.com/django-cms/django-cms/blob/003104acefed079fc92a0689683fa34cfd01c94f/cms/extensions/models.py#L42-L56). It also takes care of calling `copy_relations`.  

djangocms-versioning needs not recreate this method where it can miss the call of `copy_relations` but instead can use the original method instead.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #343 
* #342 

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
