### PR TITLE
Add caching to PageContent __bool__

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Changelog
 Unreleased
 ==========
 * feat: Reversable generic foreign key lookup from version
+* fix: Remove version check when evaluating CMS PageContent objects
 
 2.0.0rc1
 ========

--- a/djangocms_versioning/cms_config.py
+++ b/djangocms_versioning/cms_config.py
@@ -419,4 +419,3 @@ class VersioningCMSConfig(CMSAppConfig):
     cms_toolbar_mixin = CMSToolbarVersioningMixin
     PageContent.add_to_class("is_editable", indicators.is_editable)
     PageContent.add_to_class("content_indicator", indicators.content_indicator)
-    PageContent.add_to_class("__bool__", lambda self: self.versions.exists())

--- a/djangocms_versioning/test_utils/factories.py
+++ b/djangocms_versioning/test_utils/factories.py
@@ -261,7 +261,7 @@ def get_plugin_language(plugin):
     """Helper function to get the language from a plugin's relationships.
     Use this in plugin factory classes
     """
-    if plugin.placeholder.source:
+    if plugin.placeholder.source is not None:
         return plugin.placeholder.source.language
     # NOTE: If plugin.placeholder.source is None then language will
     # also be None unless set manually

--- a/tests/test_cms_config.py
+++ b/tests/test_cms_config.py
@@ -107,10 +107,10 @@ class PageContentVersioningBehaviourTestCase(CMSTestCase):
 
     def test_changing_slug_changes_page_url(self):
         """Using change form to change title / slug updates path?"""
-        new_title = "new slug here"
+        new_slug = "new-slug-here"
         data = {
             "title": self.content.title,
-            "slug": new_title
+            "slug": new_slug
         }
 
         request = req_factory.get("/?language=en")
@@ -125,8 +125,8 @@ class PageContentVersioningBehaviourTestCase(CMSTestCase):
         page = Page.objects.get(pk=self.page.pk)
         url = page.get_urls().first()
 
-        self.assertEqual(url.slug, slugify(new_title))
-        self.assertEqual(url.path, slugify(new_title))
+        self.assertEqual(url.slug, new_slug)
+        self.assertEqual(url.path, new_slug)
 
 
 class VersioningExtensionUnitTestCase(CMSTestCase):


### PR DESCRIPTION
## Description

Add a cache to `PageContent.__bool__`. I've experienced that on a typical CMS edit page there are thousands of calls to this function which all result in a database query.
Obviously this cache could become stale. If you have ideas where that could happen, please share. However, reducing a page load by 2000+ SQL queries sure seems like worth a try.

## Checklist

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
