### PR TITLE
fix: Update templates for better styling w/o djangocms-admin-style

### DIFF
--- a/djangocms_versioning/helpers.py
+++ b/djangocms_versioning/helpers.py
@@ -286,23 +286,9 @@ def remove_published_where(queryset):
     """
     By default, the versioned queryset filters out so that only versions
     that are published are returned. If you need to return the full queryset
-    this method can be used.
-
-    It will modify the sql to remove `where state = 'published'`
+    use the "admin_manager" instead of "objects"
     """
-    where_children = queryset.query.where.children
-    all_except_published = [
-        lookup for lookup in where_children
-        if not (
-            lookup.lookup_name == "exact" and
-            lookup.rhs == PUBLISHED and
-            lookup.lhs.field.name == "state"
-        )
-    ]
-
-    queryset.query.where = WhereNode()
-    queryset.query.where.children = all_except_published
-    return queryset
+    raise NotImplementedError("remove_published_where has beenreplaced by ContentObj.admin_manager")
 
 
 def get_latest_admin_viewable_content(

--- a/djangocms_versioning/helpers.py
+++ b/djangocms_versioning/helpers.py
@@ -13,13 +13,12 @@ from django.contrib.contenttypes.fields import GenericRelation
 from django.contrib.contenttypes.models import ContentType
 from django.core.mail import EmailMessage
 from django.db import models
-from django.db.models.sql.where import WhereNode
 from django.template.loader import render_to_string
 from django.utils.encoding import force_str
 
 from . import versionables
 from .conf import EMAIL_NOTIFICATIONS_FAIL_SILENTLY
-from .constants import DRAFT, PUBLISHED
+from .constants import DRAFT
 
 try:
     from djangocms_internalsearch.helpers import emit_content_change

--- a/djangocms_versioning/helpers.py
+++ b/djangocms_versioning/helpers.py
@@ -287,7 +287,7 @@ def remove_published_where(queryset):
     that are published are returned. If you need to return the full queryset
     use the "admin_manager" instead of "objects"
     """
-    raise NotImplementedError("remove_published_where has beenreplaced by ContentObj.admin_manager")
+    raise NotImplementedError("remove_published_where has been replaced by ContentObj.admin_manager")
 
 
 def get_latest_admin_viewable_content(

--- a/djangocms_versioning/templates/djangocms_versioning/admin/discard_confirmation.html
+++ b/djangocms_versioning/templates/djangocms_versioning/admin/discard_confirmation.html
@@ -1,6 +1,5 @@
 {% extends "admin/base_site.html" %}
 {% load i18n admin_urls static %}
-{% block title %}{% trans "Discard Confirmation" %}{% endblock %}
 
 {% block extrahead %}
     {{ block.super }}
@@ -12,19 +11,20 @@
 {% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} delete-confirmation{% endblock %}
 
 {% block content %}
+<h1>{% block title %}{% trans "Discard Confirmation" %}{% endblock %}</h1>
 <p>{% translate "Are you sure you want to discard following version?" %}</p>
 <h3>{{ object_name }}</h3>
 <h4>{% blocktrans %}Version number: {{ version_number }}{% endblocktrans %}</h4>
 <form action="" method="POST">
     {% csrf_token %}
-    <input  class="button confirm-link js-versioning-keep-sideframe"
-            type="submit"
-            name="discard"
-            value="{% translate "Yes, I'm sure" %}">
-    <a href="{{ back_url }}">
-        <input type="button"
-               class="button js-versioning-keep-sideframe"
-               value="{% translate "No, take me back" %}">
-    </a>
+    <div class="submit-row">
+        <input  class="button confirm-link js-versioning-keep-sideframe default"
+                type="submit"
+                name="discard"
+                value="{% translate "Yes, I'm sure" %}">
+        <a href="{{ back_url }}" class="cancel-link js-versioning-keep-sideframe" role="button">
+            {% translate 'No, take me back' %}
+        </a>
+    </div>
 </form>
 {% endblock %}

--- a/djangocms_versioning/templates/djangocms_versioning/admin/revert_confirmation.html
+++ b/djangocms_versioning/templates/djangocms_versioning/admin/revert_confirmation.html
@@ -1,6 +1,5 @@
 {% extends "admin/base_site.html" %}
 {% load i18n admin_urls static %}
-{% block title %}{% translate "Revert Confirmation" %}{% endblock %}
 
 {% block extrahead %}
     {{ block.super }}
@@ -13,6 +12,7 @@
 {% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} delete-confirmation{% endblock %}
 
 {% block content %}
+<h1>{% block title %}{% translate "Revert Confirmation" %}{% endblock %}</h1>
 <p>
     {% if draft_version %}
     {% translate "Reverting to this version may cause loss of an existing draft version. Please select an option to continue" %}
@@ -24,25 +24,25 @@
 <h4>{% blocktrans %}Version number: {{ version_number }}{% endblocktrans %}</h4>
 <form action="" method="POST">
     {% csrf_token %}
-    {% if draft_version %}
-    <input  class="button revert-button confirm-link js-versioning-keep-sideframe"
-            type="submit"
-            name="discard"
-            value="{% translate 'Discard existing draft and Revert' %}">
-    <input  class="button revert-button confirm-link js-versioning-keep-sideframe"
-            name="archive"
-            type="submit"
-            value="{% translate 'Archive existing draft and Revert' %}">
-    {% else %}
-    <input  class="button revert-button confirm-link js-versioning-keep-sideframe"
-            type="submit"
-            name="revert"
-            value="{% translate "Yes, I'm sure" %}">
-    {% endif %}
-    <a href="{{ back_url }}">
-        <input type="button"
-               class="button js-versioning-keep-sideframe"
-               value="{% translate 'No, take me back' %}">
-    </a>
+    <div class="submit-row">
+        {% if draft_version %}
+        <input  class="button revert-button confirm-link js-versioning-keep-sideframe"
+                type="submit"
+                name="discard"
+                value="{% translate 'Discard existing draft and Revert' %}">
+        <input  class="button revert-button confirm-link js-versioning-keep-sideframe"
+                name="archive"
+                type="submit"
+                value="{% translate 'Archive existing draft and Revert' %}">
+        {% else %}
+        <input  class="button revert-button confirm-link js-versioning-keep-sideframe"
+                type="submit"
+                name="revert"
+                value="{% translate "Yes, I'm sure" %}">
+        {% endif %}
+        <a href="{{ back_url }}" class="cancel-link js-versioning-keep-sideframe" role="button">
+            {% translate 'No, take me back' %}
+        </a>
+    </div>
 </form>
 {% endblock %}

--- a/djangocms_versioning/templates/djangocms_versioning/admin/unpublish_confirmation.html
+++ b/djangocms_versioning/templates/djangocms_versioning/admin/unpublish_confirmation.html
@@ -1,6 +1,5 @@
 {% extends "admin/base_site.html" %}
 {% load i18n admin_urls static %}
-{% block title %}{% translate "Revert Confirmation" %}{% endblock %}
 
 {% block extrahead %}
     {{ block.super }}
@@ -12,6 +11,7 @@
 {% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} delete-confirmation{% endblock %}
 
 {% block content %}
+<h1>{% block title %}{% translate "Revert Confirmation" %}{% endblock %}</h1>
 <p>{% translate "Unpublishing will remove this version from live. Are you sure you want to unpublish?" %}</p>
 <h3>{{ object_name }}</h3>
 <h4>{% blocktrans %} Version number: {{ version_number }}{% endblocktrans %}</h4>
@@ -22,13 +22,15 @@
 </div>
 <form action="" method="POST">
     {% csrf_token %}
-    <input  class="button confirm-link js-versioning-keep-sideframe"
-            type="submit"
-            value="{% translate "Yes, I'm sure" %}">
-    <a href="{{ back_url }}">
-        <input type="button"
-               class="button js-versioning-keep-sideframe"
-               value="{% translate 'No, take me back' %}">
-    </a>
+    <div class="submit-row">
+        <input  class="button confirm-link js-versioning-keep-sideframe"
+                type="submit"
+                value="{% translate "Yes, I'm sure" %}">
+        <a href="{{ back_url }}">
+            <input type="button"
+                   class="button js-versioning-keep-sideframe"
+                   value="{% translate 'No, take me back' %}">
+        </a>
+    </div>
 </form>
 {% endblock %}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,7 +7,6 @@ from freezegun import freeze_time
 
 from djangocms_versioning.constants import DRAFT, PUBLISHED
 from djangocms_versioning.datastructures import VersionableItem, default_copy
-from djangocms_versioning.helpers import remove_published_where
 from djangocms_versioning.models import Version, VersionQuerySet
 from djangocms_versioning.test_utils import factories
 from djangocms_versioning.test_utils.polls.cms_config import PollsCMSConfig
@@ -244,11 +243,11 @@ class TestVersionQuerySet(CMSTestCase):
         version = factories.PollVersionFactory()
         self.assertEqual(Version.objects.get_for_content(version.content), version)
 
-    def test_versioned_queryset_return_full_with_helper_method(self):
+    def test_versioned_admin_manager(self):
         """With an extra helper method we can return the full queryset"""
         factories.PollVersionFactory()
         normal_count = PollContent.objects.all()
-        full_count = remove_published_where(PollContent.objects.all())
+        full_count = PollContent.admin_manager.all()
 
         self.assertEqual(normal_count.count(), 0)
         self.assertEqual(full_count.count(), 1)


### PR DESCRIPTION
## Description

This PR adds the `.submit-row` `<div>` used in Django admin for more consistent styling.

It also removes an unused left-over helper function (legacy of pre-2.0):
* `djangocms_verisoning.helpers.remove_published_where(qs)` used to patch a queryset removing the resulting SQL `WHERE` statement which restricts the queryset to include published versions only.
* It is not used in the codebase any more. Usage in djangocms-alias has been removed a while ago.
* The official pattern is to use the `admin_manager` of a versioned model which as the name indicates should only be used in the admin.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
