### PR TITLE
Bugfix/use keyword arguments in admin render change form method

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog
 
 Unreleased
 ==========
+* fix: Add keyword arguments in VersionAdminMixin render_change_form
 * feat: Reversable generic foreign key lookup from version
 * fix: formatted files through ruff to fix tests
 * fix: Remove version check when evaluating CMS PageContent objects

--- a/djangocms_versioning/admin.py
+++ b/djangocms_versioning/admin.py
@@ -133,7 +133,7 @@ class VersioningAdminMixin:
                 "versioning_fallback_change_form_template"
             ] = super().change_form_template
 
-        return super().render_change_form(request, context, add, change, form_url, obj)
+        return super().render_change_form(request, context, add=add, change=change, form_url=form_url, obj=obj)
 
     def has_change_permission(self, request, obj=None):
         # Add additional version checks


### PR DESCRIPTION
## Description

Using keyword arguments in Render change form method for VersioningAdminMixin
