### PR TITLE
fix: Preview link language

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ 3.9, "3.10", "3.11" ]  # latest release minus two
+        python-version: [ 3.9, "3.10", "3.11", "3.12" ]  # latest release minus two
         requirements-file: [
             dj32_cms41.txt,
             dj40_cms41.txt,
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ 3.9, "3.10", "3.11" ]  # latest release minus two
+        python-version: [ 3.9, "3.10", "3.11", "3.12" ]  # latest release minus two
         requirements-file: [
             dj32_cms41.txt,
             dj40_cms41.txt,
@@ -90,7 +90,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ 3.9, "3.10", "3.11" ]  # latest release minus two
+        python-version: [ 3.9, "3.10", "3.11", "3.12" ]  # latest release minus two
         requirements-file: [
             dj32_cms41.txt,
             dj40_cms41.txt,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  sqlite-unit-tests:
+  sqlite:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -39,7 +39,7 @@ jobs:
     - name: Upload Coverage to Codecov
       uses: codecov/codecov-action@v2
 
-  postgres-unit-tests:
+  postgres:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -85,7 +85,7 @@ jobs:
     - name: Upload Coverage to Codecov
       uses: codecov/codecov-action@v2
 
-  mysql-unit-tests:
+  mysql:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/djangocms_versioning/admin.py
+++ b/djangocms_versioning/admin.py
@@ -33,7 +33,7 @@ from django.urls import Resolver404, path, resolve, reverse
 from django.utils.encoding import force_str
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
-from django.utils.translation import gettext_lazy as _, get_language
+from django.utils.translation import gettext_lazy as _
 
 from . import conf, versionables
 from .constants import DRAFT, INDICATOR_DESCRIPTIONS, PUBLISHED, VERSION_STATES

--- a/djangocms_versioning/admin.py
+++ b/djangocms_versioning/admin.py
@@ -1206,7 +1206,7 @@ class VersionAdmin(ChangeListActionsMixin, admin.ModelAdmin, metaclass=MediaDefi
                 context.update(
                     {
                         "v2": v2,
-                        "v2_preview_url": add_url_parameters(v2_preview_url, **persist_params),
+                        "v2_preview_url": v2_preview_url,
                     }
                 )
         return TemplateResponse(

--- a/djangocms_versioning/admin.py
+++ b/djangocms_versioning/admin.py
@@ -33,7 +33,7 @@ from django.urls import Resolver404, path, resolve, reverse
 from django.utils.encoding import force_str
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _, get_language
 
 from . import conf, versionables
 from .constants import DRAFT, INDICATOR_DESCRIPTIONS, PUBLISHED, VERSION_STATES
@@ -1177,13 +1177,8 @@ class VersionAdmin(ChangeListActionsMixin, admin.ModelAdmin, metaclass=MediaDefi
             get_cms_setting("CMS_TOOLBAR_URL__DISABLE"): 1,
             get_cms_setting("CMS_TOOLBAR_URL__PERSIST"): 0,
         }
-        v1_preview_url = add_url_parameters(
-            reverse(
-                "admin:cms_placeholder_render_object_preview",
-                args=(v1.content_type_id, v1.object_id),
-            ),
-            **persist_params
-        )
+        v1_preview_url = get_preview_url(v1.content)
+        v1_preview_url = add_url_parameters(v1_preview_url, **persist_params)
         # Get the list of versions for the grouper. This is for use
         # in the dropdown to choose a version.
         version_list = Version.objects.filter_by_content_grouping_values(
@@ -1206,16 +1201,12 @@ class VersionAdmin(ChangeListActionsMixin, admin.ModelAdmin, metaclass=MediaDefi
                     request, self.model._meta, request.GET["compare_to"]
                 )
             else:
+                v2_preview_url = get_preview_url(v2.content)
+                v2_preview_url = add_url_parameters(v2_preview_url, **persist_params)
                 context.update(
                     {
                         "v2": v2,
-                        "v2_preview_url": add_url_parameters(
-                            reverse(
-                                "admin:cms_placeholder_render_object_preview",
-                                args=(v2.content_type_id, v2.object_id),
-                            ),
-                            **persist_params
-                        ),
+                        "v2_preview_url": add_url_parameters(v2_preview_url, **persist_params),
                     }
                 )
         return TemplateResponse(

--- a/djangocms_versioning/cms_config.py
+++ b/djangocms_versioning/cms_config.py
@@ -32,10 +32,11 @@ from .exceptions import ConditionFailed
 from .helpers import (
     get_latest_admin_viewable_content,
     inject_generic_relation_to_version,
+    is_editable,
     placeholder_content_is_unlocked_for_user,
     register_versionadmin_proxy,
     replace_admin_for_models,
-    replace_manager, is_editable,
+    replace_manager,
 )
 from .managers import AdminManagerMixin, PublishedContentManagerMixin
 from .models import Version

--- a/djangocms_versioning/cms_config.py
+++ b/djangocms_versioning/cms_config.py
@@ -35,7 +35,7 @@ from .helpers import (
     placeholder_content_is_unlocked_for_user,
     register_versionadmin_proxy,
     replace_admin_for_models,
-    replace_manager,
+    replace_manager, is_editable,
 )
 from .managers import AdminManagerMixin, PublishedContentManagerMixin
 from .models import Version
@@ -408,5 +408,5 @@ class VersioningCMSConfig(CMSAppConfig):
         )
     ]
     cms_toolbar_mixin = CMSToolbarVersioningMixin
-    PageContent.add_to_class("is_editable", indicators.is_editable)
+    PageContent.add_to_class("is_editable", is_editable)
     PageContent.add_to_class("content_indicator", indicators.content_indicator)

--- a/djangocms_versioning/cms_menus.py
+++ b/djangocms_versioning/cms_menus.py
@@ -94,7 +94,7 @@ class CMSMenu(Menu):
 
         # Depending on the toolbar mode, we need to get the correct version.
         # On edit or preview mode: return DRAFT,
-        # if DRAFT does not exists then return PUBLISHED.
+        # if DRAFT does not exist then return PUBLISHED.
         # On public mode: return PUBLISHED.
         if edit_or_preview:
             states = [constants.DRAFT, constants.PUBLISHED]

--- a/djangocms_versioning/cms_toolbars.py
+++ b/djangocms_versioning/cms_toolbars.py
@@ -299,7 +299,7 @@ class VersioningPageToolbar(PageToolbar):
         return get_latest_admin_viewable_content(self.page, language=language)
 
     def populate(self):
-        self.page = self.request.current_page or getattr(self.toolbar.obj, "page", None)
+        self.page = self.request.current_page
         self.title = self.get_page_content() if self.page else None
         self.permissions_activated = get_cms_setting("PERMISSION")
 

--- a/djangocms_versioning/cms_toolbars.py
+++ b/djangocms_versioning/cms_toolbars.py
@@ -299,7 +299,7 @@ class VersioningPageToolbar(PageToolbar):
         return get_latest_admin_viewable_content(self.page, language=language)
 
     def populate(self):
-        self.page = self.request.current_page
+        self.page = self.request.current_page or getattr(self.toolbar.obj, "page", None)
         self.title = self.get_page_content() if self.page else None
         self.permissions_activated = get_cms_setting("PERMISSION")
 

--- a/djangocms_versioning/helpers.py
+++ b/djangocms_versioning/helpers.py
@@ -15,6 +15,7 @@ from django.core.mail import EmailMessage
 from django.db import models
 from django.template.loader import render_to_string
 from django.utils.encoding import force_str
+from django.utils.translation import get_language
 
 from . import versionables
 from .conf import EMAIL_NOTIFICATIONS_FAIL_SILENTLY
@@ -263,6 +264,9 @@ def get_preview_url(content_obj: models.Model, language: typing.Union[str, None]
     if versionable.preview_url:
         return versionable.preview_url(content_obj)
     if is_editable_model(content_obj.__class__):
+        if not language:
+            # Use language field is content object has one to determine the language
+            language = getattr(content_obj, "language", get_language())
         url = get_object_preview_url(content_obj, language=language)
         # Or else, the standard change view should be used
     else:

--- a/djangocms_versioning/helpers.py
+++ b/djangocms_versioning/helpers.py
@@ -286,23 +286,9 @@ def remove_published_where(queryset):
     """
     By default, the versioned queryset filters out so that only versions
     that are published are returned. If you need to return the full queryset
-    this method can be used.
-
-    It will modify the sql to remove `where state = 'published'`
+    use the "admin_manager" instead of "objects"
     """
-    where_children = queryset.query.where.children
-    all_except_published = [
-        lookup for lookup in where_children
-        if not (
-            lookup.lookup_name == "exact" and
-            lookup.rhs == PUBLISHED and
-            lookup.lhs.field.name == "state"
-        )
-    ]
-
-    queryset.query.where = WhereNode()
-    queryset.query.where.children = all_except_published
-    return queryset
+    raise NotImplementedError("remove_published_where has beenreplaced by ContentObj.admin_manager")
 
 
 def get_latest_admin_viewable_content(

--- a/djangocms_versioning/helpers.py
+++ b/djangocms_versioning/helpers.py
@@ -15,7 +15,6 @@ from django.core.mail import EmailMessage
 from django.db import models
 from django.template.loader import render_to_string
 from django.utils.encoding import force_str
-from django.utils.translation import get_language
 
 from . import versionables
 from .conf import EMAIL_NOTIFICATIONS_FAIL_SILENTLY

--- a/djangocms_versioning/helpers.py
+++ b/djangocms_versioning/helpers.py
@@ -27,6 +27,11 @@ except ImportError:
     emit_content_change = None
 
 
+def is_editable(content_obj, request):
+    """Check of content_obj is editable"""
+    return content_obj.versions.first().check_modify.as_bool(request.user)
+
+
 def versioning_admin_factory(admin_class, mixin):
     """A class factory returning admin class with overriden
     versioning functionality.
@@ -148,6 +153,8 @@ def inject_generic_relation_to_version(model):
     related_query_name = f"{model._meta.app_label}_{model._meta.model_name}"
     model.add_to_class("versions", GenericRelation(
         Version, related_query_name=related_query_name))
+    if not hasattr(model, "is_editable"):
+        model.add_to_class("is_editable", is_editable)
 
 
 def _set_default_manager(model, manager):
@@ -229,8 +236,7 @@ def get_editable_url(content_obj):
        This method is provides the URL for it.
     """
     if is_editable_model(content_obj.__class__):
-        language = getattr(content_obj, "language", None)
-        url = get_object_edit_url(content_obj, language)
+        url = get_object_edit_url(content_obj)
     # Or else, the standard edit view should be used
     else:
         url = admin_reverse(
@@ -264,12 +270,9 @@ def get_preview_url(content_obj: models.Model, language: typing.Union[str, None]
     if versionable.preview_url:
         return versionable.preview_url(content_obj)
     if is_editable_model(content_obj.__class__):
-        if not language:
-            # Use language field is content object has one to determine the language
-            language = getattr(content_obj, "language", get_language())
         url = get_object_preview_url(content_obj, language=language)
-        # Or else, the standard change view should be used
     else:
+        # Or else, the standard change view should be used
         url = admin_reverse(
             f"{content_obj._meta.app_label}_{content_obj._meta.model_name}_change",
             args=[content_obj.pk],

--- a/djangocms_versioning/helpers.py
+++ b/djangocms_versioning/helpers.py
@@ -235,7 +235,8 @@ def get_editable_url(content_obj):
        This method is provides the URL for it.
     """
     if is_editable_model(content_obj.__class__):
-        url = get_object_edit_url(content_obj)
+        language = getattr(content_obj, "language", None)
+        url = get_object_edit_url(content_obj, language)
     # Or else, the standard edit view should be used
     else:
         url = admin_reverse(

--- a/djangocms_versioning/helpers.py
+++ b/djangocms_versioning/helpers.py
@@ -28,7 +28,9 @@ except ImportError:
 
 def is_editable(content_obj, request):
     """Check of content_obj is editable"""
-    return content_obj.versions.first().check_modify.as_bool(request.user)
+    from .models import Version
+
+    return Version.objects.get_for_content(content_obj).check_modify.as_bool(request.user)
 
 
 def versioning_admin_factory(admin_class, mixin):

--- a/djangocms_versioning/indicators.py
+++ b/djangocms_versioning/indicators.py
@@ -120,12 +120,3 @@ def content_indicator(content_obj):
             content_obj._indicator_status = None
             content_obj._version = [None]
     return content_obj._indicator_status
-
-
-def is_editable(content_obj, request):
-    """Check of content_obj is editable"""
-    if not content_obj.content_indicator():
-        # Something's wrong: content indicator not identified. Maybe no version?
-        return False
-    versions = content_obj._version
-    return versions[0].check_modify.as_bool(request.user)

--- a/djangocms_versioning/locale/de/LC_MESSAGES/django.po
+++ b/djangocms_versioning/locale/de/LC_MESSAGES/django.po
@@ -11,115 +11,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-05 17:59+0200\n"
+"POT-Creation-Date: 2023-10-02 09:37+0200\n"
 "PO-Revision-Date: 2023-01-10 15:29+0000\n"
 "Last-Translator: Fabian Braun <fsbraun@gmx.de>, 2023\n"
 "Language-Team: German (https://app.transifex.com/divio/teams/58664/de/)\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: admin.py:164 admin.py:301 admin.py:383
+#: admin.py:164 admin.py:301 admin.py:377
 msgid "State"
 msgstr "Status"
 
-#: admin.py:192 constants.py:28
+#: admin.py:192 constants.py:27
 msgid "Empty"
 msgstr "Leer"
 
-#: admin.py:315 admin.py:395
+#: admin.py:315 admin.py:387
 msgid "Author"
 msgstr "Autor"
 
-#: admin.py:329 admin.py:406 models.py:89
+#: admin.py:329 admin.py:401 models.py:87
 msgid "Modified"
 msgstr "Geändert"
 
-#: admin.py:433 admin.py:661
+#: admin.py:437 admin.py:667
 #: templates/djangocms_versioning/admin/icons/preview.html:3
 #: templates/djangocms_versioning/admin/preview.html:3
 msgid "Preview"
 msgstr "Vorschau"
 
-#: admin.py:468 admin.py:760 cms_toolbars.py:121
+#: admin.py:470 admin.py:758 cms_toolbars.py:115
 #: templates/djangocms_versioning/admin/icons/edit_icon.html:3
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: admin.py:480
+#: admin.py:482
 #: templates/djangocms_versioning/admin/icons/manage_versions.html:3
 msgid "Manage versions"
 msgstr "Versionen verwalten"
 
-#: admin.py:639
+#: admin.py:631
 msgid "Content"
 msgstr "Inhalt"
 
-#: admin.py:649
+#: admin.py:647
 msgid "locked"
 msgstr "gesperrt"
 
-#: admin.py:679 templates/djangocms_versioning/admin/icons/archive_icon.html:3
+#: admin.py:683 templates/djangocms_versioning/admin/icons/archive_icon.html:3
 msgid "Archive"
 msgstr "Archivieren"
 
-#: admin.py:699 cms_toolbars.py:83 indicators.py:41
+#: admin.py:701 cms_toolbars.py:79 indicators.py:34
 #: templates/djangocms_versioning/admin/icons/publish_icon.html:3
 msgid "Publish"
 msgstr "Veröffentlichen"
 
-#: admin.py:721 indicators.py:61 indicators.py:67
+#: admin.py:721 indicators.py:54 indicators.py:60
 #: templates/djangocms_versioning/admin/icons/unpublish_icon.html:3
 msgid "Unpublish"
 msgstr "Veröffentlichung aufheben"
 
-#: admin.py:760 cms_toolbars.py:121
+#: admin.py:758 cms_toolbars.py:115
 msgid "New Draft"
 msgstr "Neuer Entwurf"
 
-#: admin.py:783 cms_toolbars.py:188
+#: admin.py:779 cms_toolbars.py:177
 #: templates/djangocms_versioning/admin/icons/revert_icon.html:3
 msgid "Revert"
 msgstr "Zurückholen"
 
-#: admin.py:804 templates/djangocms_versioning/admin/icons/discard_icon.html:3
+#: admin.py:798 templates/djangocms_versioning/admin/icons/discard_icon.html:3
 msgid "Discard"
 msgstr "Verwerfen"
 
-#: admin.py:829 cms_toolbars.py:153
+#: admin.py:821 cms_toolbars.py:145
 msgid "Unlock"
 msgstr "Entsperren"
 
 #: admin.py:856
-msgid "Exactly two versions need to be selected."
-msgstr "Genau zwei Versionen müssen ausgewählt werden."
-
-#: admin.py:870
 msgid "Compare versions"
 msgstr "Versionen vergleichen"
 
-#: admin.py:897
+#: admin.py:866
+msgid "Exactly two versions need to be selected."
+msgstr "Genau zwei Versionen müssen ausgewählt werden."
+
+#: admin.py:903
 msgid "Version cannot be archived"
 msgstr "Version kann nicht archiviert werden"
 
-#: admin.py:926
+#: admin.py:929
 msgid "Version archived"
 msgstr "Version archiviert"
 
-#: admin.py:937 admin.py:1059 admin.py:1241
+#: admin.py:940 admin.py:1059 admin.py:1235
 msgid "This view only supports POST method."
 msgstr "Dieser View unterstützt nur die POST-Methode."
 
-#: admin.py:948
+#: admin.py:951
 msgid "Version cannot be published"
 msgstr "Version kann nicht veröffentlicht werden"
 
-#: admin.py:959
+#: admin.py:962
 msgid "Version published"
 msgstr "Version veröffentlicht"
 
-#: admin.py:976
+#: admin.py:979
 msgid "Version cannot be unpublished"
 msgstr "Die Veröffentlichung kann nicht aufgehoben werden"
 
@@ -127,19 +128,19 @@ msgstr "Die Veröffentlichung kann nicht aufgehoben werden"
 msgid "Version unpublished"
 msgstr "Veröffentlichung aufgehoben"
 
-#: admin.py:1169
+#: admin.py:1163
 msgid "The last version has been deleted"
 msgstr "Die neueste Version wurde gelöscht"
 
-#: admin.py:1255
+#: admin.py:1249
 msgid "You do not have permission to remove the version lock"
 msgstr "Keine Berechtigung vorhanden, um die Sperrung der Version aufzuheben."
 
-#: admin.py:1260
+#: admin.py:1254
 msgid "Version unlocked"
 msgstr "Version entsperrt"
 
-#: admin.py:1309
+#: admin.py:1303
 #, python-brace-format
 msgid "Displaying versions of \"{grouper}\""
 msgstr "Zeige Versionen von \"{grouper}\""
@@ -148,180 +149,180 @@ msgstr "Zeige Versionen von \"{grouper}\""
 msgid "django CMS Versioning"
 msgstr "django CMS Versioning"
 
-#: cms_config.py:262
+#: cms_config.py:246
 msgid "No available title"
 msgstr "Kein Titel verfügbar"
 
-#: cms_config.py:264 constants.py:13 constants.py:26
+#: cms_config.py:248 constants.py:12 constants.py:25
 msgid "Unpublished"
 msgstr "Veröffentlichung aufgehoben"
 
-#: cms_config.py:358
+#: cms_config.py:342
 msgid "Language must be set to a supported language!"
 msgstr "Eine unterstützte Sprache muss ausgewählt sein!"
 
-#: cms_config.py:376
+#: cms_config.py:360
 msgid "You do not have permission to copy these plugins."
 msgstr "Keine Erlaubnis, diese Plugins zu kopieren."
 
-#: cms_toolbars.py:218
+#: cms_toolbars.py:207
 msgid "Manage Versions"
 msgstr "Versionen verwalten"
 
-#: cms_toolbars.py:221
+#: cms_toolbars.py:210
 #, python-brace-format
 msgid "Compare to {source}"
 msgstr "Mit {source} vergleichen"
 
-#: cms_toolbars.py:236 indicators.py:73
+#: cms_toolbars.py:226 indicators.py:66
 msgid "Discard Changes"
 msgstr "Änderungen verwerfen"
 
-#: cms_toolbars.py:271
+#: cms_toolbars.py:262
 msgid "View Published"
 msgstr "Veröffentlichung ansehen"
 
-#: cms_toolbars.py:327
+#: cms_toolbars.py:317
 msgid "Language"
 msgstr "Sprache"
 
-#: cms_toolbars.py:374
+#: cms_toolbars.py:364
 msgid "Add Translation"
 msgstr "Übersetzung hinzufügen"
 
-#: cms_toolbars.py:387
+#: cms_toolbars.py:377
 msgid "Copy all plugins"
 msgstr "Alle Plugins kopieren"
 
-#: cms_toolbars.py:389
+#: cms_toolbars.py:379
 #, python-format
 msgid "from %s"
 msgstr "von %s"
 
-#: cms_toolbars.py:390
+#: cms_toolbars.py:380
 #, python-format
 msgid "Are you sure you want to copy all plugins from %s?"
 msgstr "Sind Sie sicher, dass sie alle Plugins von %s kopieren wollen?"
 
-#: cms_toolbars.py:405
+#: cms_toolbars.py:395
 msgid "No other language available"
 msgstr "Keine andere Sprache verfügbar"
 
-#: constants.py:11 constants.py:25
+#: constants.py:10 constants.py:24
 msgid "Draft"
 msgstr "Entwurf"
 
-#: constants.py:12 constants.py:23
+#: constants.py:11 constants.py:22
 msgid "Published"
 msgstr "Veröffentlicht"
 
-#: constants.py:14 constants.py:27
+#: constants.py:13 constants.py:26
 msgid "Archived"
 msgstr "Archiviert"
 
-#: constants.py:24
+#: constants.py:23
 msgid "Changed"
 msgstr "Verändert"
 
-#: emails.py:38
+#: emails.py:39
 msgid "Unlocked"
 msgstr "Entsperrt"
 
-#: indicators.py:35
+#: indicators.py:28
 #, python-format
 msgid "Unlock (%(message)s)"
 msgstr "Entsperren (%(message)s)"
 
-#: indicators.py:47
+#: indicators.py:40
 msgid "Create new draft"
 msgstr "Neuen Entwurf erstellen"
 
-#: indicators.py:53
+#: indicators.py:46
 msgid "Revert from Unpublish"
 msgstr "Zurückholen"
 
-#: indicators.py:73
+#: indicators.py:66
 msgid "Delete Draft"
 msgstr "Entwurf löschen"
 
-#: indicators.py:79
+#: indicators.py:72
 msgid "Compare Draft to Published..."
 msgstr "Entwurf mit Veröffentlichung vergleichen..."
 
-#: indicators.py:89
+#: indicators.py:82
 msgid "Manage Versions..."
 msgstr "Versionen verwalten..."
 
-#: models.py:31
+#: models.py:29
 msgid "Version is not a draft"
 msgstr "Version ist kein Entwurf"
 
-#: models.py:32
+#: models.py:30
 #, python-brace-format
 msgid "Action Denied. The latest version is locked by {user}"
 msgstr "Aktion verweigert. Die aktuelle Version ist von {user} gesperrt."
 
-#: models.py:33
+#: models.py:31
 #, python-brace-format
 msgid "Action Denied. The draft version is locked by {user}"
 msgstr "Aktion verweigert. Der Entwurf ist von {user} gesperrt."
 
-#: models.py:88
+#: models.py:86
 msgid "Created"
 msgstr "Erstellt"
 
-#: models.py:91
+#: models.py:89
 msgid "author"
 msgstr "Autor"
 
-#: models.py:100
+#: models.py:102
 msgid "status"
 msgstr "Status"
 
-#: models.py:108
+#: models.py:110
 msgid "locked by"
 msgstr "gesperrt von"
 
-#: models.py:117
+#: models.py:119
 msgid "source"
 msgstr "Ursprung"
 
-#: models.py:131
+#: models.py:133
 #, python-brace-format
 msgid "Version #{number} ({state} {date})"
 msgstr "Version #{number} ({state} {date}) "
 
-#: models.py:138
+#: models.py:140
 #, python-brace-format
 msgid "Version #{number} ({state})"
 msgstr "Version #{number} ({state})"
 
-#: models.py:144
+#: models.py:146
 #, python-format
 msgid "Locked by %(user)s"
 msgstr "Gesperrt von %(user)s"
 
-#: models.py:276 models.py:325
+#: models.py:278 models.py:327
 msgid "Version is not in draft state"
 msgstr "Version ist kein Entwurf"
 
-#: models.py:385
+#: models.py:387
 msgid "Version is not in published state"
 msgstr "Version ist nicht veröffentlicht"
 
-#: models.py:442
+#: models.py:444
 msgid "Version is not in archived or unpublished state"
 msgstr "Version ist weder archiviert noch eine Veröffentlichung aufgehoben"
 
-#: models.py:457
+#: models.py:459
 msgid "Version is not in draft or published state"
 msgstr "Version ist weder ein Entwurf noch veröffentlicht"
 
-#: models.py:465
+#: models.py:467
 msgid "Version is already locked"
 msgstr "Version bereits gesperrt"
 
-#: models.py:471
+#: models.py:473
 msgid "Draft version is not locked"
 msgstr "Entwurf ist nicht gesperrt"
 
@@ -489,7 +490,8 @@ msgid ""
 "The following draft version has been unlocked by %(by_user)s for their use.\n"
 "%(version_link)s\n"
 "\n"
-"Please note you will not be able to further edit this draft. Kindly reach out to %(by_user)s in case of any concerns.\n"
+"Please note you will not be able to further edit this draft. Kindly reach "
+"out to %(by_user)s in case of any concerns.\n"
 "\n"
 "This is an automated notification from Django CMS.\n"
 msgstr ""
@@ -498,6 +500,7 @@ msgstr ""
 "\n"
 "%(version_link)s\n"
 "\n"
-"Bitte beachte, dass Du diesen Entwurf nicht mehr ändern kannst. Bitte kontaktiere %(by_user)s für Rückfragen.\n"
+"Bitte beachte, dass Du diesen Entwurf nicht mehr ändern kannst. Bitte "
+"kontaktiere %(by_user)s für Rückfragen.\n"
 "\n"
 "Dies ist eine automatisierte Nachricht von Django CMS.\n"

--- a/djangocms_versioning/locale/en/LC_MESSAGES/django.po
+++ b/djangocms_versioning/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-05 17:59+0200\n"
+"POT-Creation-Date: 2023-10-02 09:37+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,106 +18,106 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: admin.py:164 admin.py:301 admin.py:383
+#: admin.py:164 admin.py:301 admin.py:377
 msgid "State"
 msgstr ""
 
-#: admin.py:192 constants.py:28
+#: admin.py:192 constants.py:27
 msgid "Empty"
 msgstr ""
 
-#: admin.py:315 admin.py:395
+#: admin.py:315 admin.py:387
 msgid "Author"
 msgstr ""
 
-#: admin.py:329 admin.py:406 models.py:89
+#: admin.py:329 admin.py:401 models.py:87
 msgid "Modified"
 msgstr ""
 
-#: admin.py:433 admin.py:661
+#: admin.py:437 admin.py:667
 #: templates/djangocms_versioning/admin/icons/preview.html:3
 #: templates/djangocms_versioning/admin/preview.html:3
 msgid "Preview"
 msgstr ""
 
-#: admin.py:468 admin.py:760 cms_toolbars.py:121
+#: admin.py:470 admin.py:758 cms_toolbars.py:115
 #: templates/djangocms_versioning/admin/icons/edit_icon.html:3
 msgid "Edit"
 msgstr ""
 
-#: admin.py:480
+#: admin.py:482
 #: templates/djangocms_versioning/admin/icons/manage_versions.html:3
 msgid "Manage versions"
 msgstr ""
 
-#: admin.py:639
+#: admin.py:631
 msgid "Content"
 msgstr ""
 
-#: admin.py:649
+#: admin.py:647
 msgid "locked"
 msgstr ""
 
-#: admin.py:679 templates/djangocms_versioning/admin/icons/archive_icon.html:3
+#: admin.py:683 templates/djangocms_versioning/admin/icons/archive_icon.html:3
 msgid "Archive"
 msgstr ""
 
-#: admin.py:699 cms_toolbars.py:83 indicators.py:41
+#: admin.py:701 cms_toolbars.py:79 indicators.py:34
 #: templates/djangocms_versioning/admin/icons/publish_icon.html:3
 msgid "Publish"
 msgstr ""
 
-#: admin.py:721 indicators.py:61 indicators.py:67
+#: admin.py:721 indicators.py:54 indicators.py:60
 #: templates/djangocms_versioning/admin/icons/unpublish_icon.html:3
 msgid "Unpublish"
 msgstr ""
 
-#: admin.py:760 cms_toolbars.py:121
+#: admin.py:758 cms_toolbars.py:115
 msgid "New Draft"
 msgstr ""
 
-#: admin.py:783 cms_toolbars.py:188
+#: admin.py:779 cms_toolbars.py:177
 #: templates/djangocms_versioning/admin/icons/revert_icon.html:3
 msgid "Revert"
 msgstr ""
 
-#: admin.py:804 templates/djangocms_versioning/admin/icons/discard_icon.html:3
+#: admin.py:798 templates/djangocms_versioning/admin/icons/discard_icon.html:3
 msgid "Discard"
 msgstr ""
 
-#: admin.py:829 cms_toolbars.py:153
+#: admin.py:821 cms_toolbars.py:145
 msgid "Unlock"
 msgstr ""
 
 #: admin.py:856
-msgid "Exactly two versions need to be selected."
-msgstr ""
-
-#: admin.py:870
 msgid "Compare versions"
 msgstr ""
 
-#: admin.py:897
+#: admin.py:866
+msgid "Exactly two versions need to be selected."
+msgstr ""
+
+#: admin.py:903
 msgid "Version cannot be archived"
 msgstr ""
 
-#: admin.py:926
+#: admin.py:929
 msgid "Version archived"
 msgstr ""
 
-#: admin.py:937 admin.py:1059 admin.py:1241
+#: admin.py:940 admin.py:1059 admin.py:1235
 msgid "This view only supports POST method."
 msgstr ""
 
-#: admin.py:948
+#: admin.py:951
 msgid "Version cannot be published"
 msgstr ""
 
-#: admin.py:959
+#: admin.py:962
 msgid "Version published"
 msgstr ""
 
-#: admin.py:976
+#: admin.py:979
 msgid "Version cannot be unpublished"
 msgstr ""
 
@@ -125,19 +125,19 @@ msgstr ""
 msgid "Version unpublished"
 msgstr ""
 
-#: admin.py:1169
+#: admin.py:1163
 msgid "The last version has been deleted"
 msgstr ""
 
-#: admin.py:1255
+#: admin.py:1249
 msgid "You do not have permission to remove the version lock"
 msgstr ""
 
-#: admin.py:1260
+#: admin.py:1254
 msgid "Version unlocked"
 msgstr ""
 
-#: admin.py:1309
+#: admin.py:1303
 #, python-brace-format
 msgid "Displaying versions of \"{grouper}\""
 msgstr ""
@@ -146,180 +146,180 @@ msgstr ""
 msgid "django CMS Versioning"
 msgstr ""
 
-#: cms_config.py:262
+#: cms_config.py:246
 msgid "No available title"
 msgstr ""
 
-#: cms_config.py:264 constants.py:13 constants.py:26
+#: cms_config.py:248 constants.py:12 constants.py:25
 msgid "Unpublished"
 msgstr ""
 
-#: cms_config.py:358
+#: cms_config.py:342
 msgid "Language must be set to a supported language!"
 msgstr ""
 
-#: cms_config.py:376
+#: cms_config.py:360
 msgid "You do not have permission to copy these plugins."
 msgstr ""
 
-#: cms_toolbars.py:218
+#: cms_toolbars.py:207
 msgid "Manage Versions"
 msgstr ""
 
-#: cms_toolbars.py:221
+#: cms_toolbars.py:210
 #, python-brace-format
 msgid "Compare to {source}"
 msgstr ""
 
-#: cms_toolbars.py:236 indicators.py:73
+#: cms_toolbars.py:226 indicators.py:66
 msgid "Discard Changes"
 msgstr ""
 
-#: cms_toolbars.py:271
+#: cms_toolbars.py:262
 msgid "View Published"
 msgstr ""
 
-#: cms_toolbars.py:327
+#: cms_toolbars.py:317
 msgid "Language"
 msgstr ""
 
-#: cms_toolbars.py:374
+#: cms_toolbars.py:364
 msgid "Add Translation"
 msgstr ""
 
-#: cms_toolbars.py:387
+#: cms_toolbars.py:377
 msgid "Copy all plugins"
 msgstr ""
 
-#: cms_toolbars.py:389
+#: cms_toolbars.py:379
 #, python-format
 msgid "from %s"
 msgstr ""
 
-#: cms_toolbars.py:390
+#: cms_toolbars.py:380
 #, python-format
 msgid "Are you sure you want to copy all plugins from %s?"
 msgstr ""
 
-#: cms_toolbars.py:405
+#: cms_toolbars.py:395
 msgid "No other language available"
 msgstr ""
 
-#: constants.py:11 constants.py:25
+#: constants.py:10 constants.py:24
 msgid "Draft"
 msgstr ""
 
-#: constants.py:12 constants.py:23
+#: constants.py:11 constants.py:22
 msgid "Published"
 msgstr ""
 
-#: constants.py:14 constants.py:27
+#: constants.py:13 constants.py:26
 msgid "Archived"
 msgstr ""
 
-#: constants.py:24
+#: constants.py:23
 msgid "Changed"
 msgstr ""
 
-#: emails.py:38
+#: emails.py:39
 msgid "Unlocked"
 msgstr ""
 
-#: indicators.py:35
+#: indicators.py:28
 #, python-format
 msgid "Unlock (%(message)s)"
 msgstr ""
 
-#: indicators.py:47
+#: indicators.py:40
 msgid "Create new draft"
 msgstr ""
 
-#: indicators.py:53
+#: indicators.py:46
 msgid "Revert from Unpublish"
 msgstr ""
 
-#: indicators.py:73
+#: indicators.py:66
 msgid "Delete Draft"
 msgstr ""
 
-#: indicators.py:79
+#: indicators.py:72
 msgid "Compare Draft to Published..."
 msgstr ""
 
-#: indicators.py:89
+#: indicators.py:82
 msgid "Manage Versions..."
 msgstr ""
 
-#: models.py:31
+#: models.py:29
 msgid "Version is not a draft"
 msgstr ""
 
-#: models.py:32
+#: models.py:30
 #, python-brace-format
 msgid "Action Denied. The latest version is locked by {user}"
 msgstr ""
 
-#: models.py:33
+#: models.py:31
 #, python-brace-format
 msgid "Action Denied. The draft version is locked by {user}"
 msgstr ""
 
-#: models.py:88
+#: models.py:86
 msgid "Created"
 msgstr ""
 
-#: models.py:91
+#: models.py:89
 msgid "author"
 msgstr ""
 
-#: models.py:100
+#: models.py:102
 msgid "status"
 msgstr ""
 
-#: models.py:108
+#: models.py:110
 msgid "locked by"
 msgstr ""
 
-#: models.py:117
+#: models.py:119
 msgid "source"
 msgstr ""
 
-#: models.py:131
+#: models.py:133
 #, python-brace-format
 msgid "Version #{number} ({state} {date})"
 msgstr ""
 
-#: models.py:138
+#: models.py:140
 #, python-brace-format
 msgid "Version #{number} ({state})"
 msgstr ""
 
-#: models.py:144
+#: models.py:146
 #, python-format
 msgid "Locked by %(user)s"
 msgstr ""
 
-#: models.py:276 models.py:325
+#: models.py:278 models.py:327
 msgid "Version is not in draft state"
 msgstr ""
 
-#: models.py:385
+#: models.py:387
 msgid "Version is not in published state"
 msgstr ""
 
-#: models.py:442
+#: models.py:444
 msgid "Version is not in archived or unpublished state"
 msgstr ""
 
-#: models.py:457
+#: models.py:459
 msgid "Version is not in draft or published state"
 msgstr ""
 
-#: models.py:465
+#: models.py:467
 msgid "Version is already locked"
 msgstr ""
 
-#: models.py:471
+#: models.py:473
 msgid "Draft version is not locked"
 msgstr ""
 

--- a/djangocms_versioning/locale/fr/LC_MESSAGES/django.po
+++ b/djangocms_versioning/locale/fr/LC_MESSAGES/django.po
@@ -2,126 +2,127 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # François Palmier <fp@kapt.mobi>, 2023
 # Frédéric Roland, 2023
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-05 17:59+0200\n"
+"POT-Creation-Date: 2023-10-02 09:37+0200\n"
 "PO-Revision-Date: 2023-01-10 15:29+0000\n"
 "Last-Translator: Frédéric Roland, 2023\n"
 "Language-Team: French (https://app.transifex.com/divio/teams/58664/fr/)\n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: fr\n"
-"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % "
+"1000000 == 0 ? 1 : 2;\n"
 
-#: admin.py:164 admin.py:301 admin.py:383
+#: admin.py:164 admin.py:301 admin.py:377
 msgid "State"
 msgstr "État"
 
-#: admin.py:192 constants.py:28
+#: admin.py:192 constants.py:27
 msgid "Empty"
 msgstr "Vide"
 
-#: admin.py:315 admin.py:395
+#: admin.py:315 admin.py:387
 msgid "Author"
 msgstr "Auteur"
 
-#: admin.py:329 admin.py:406 models.py:89
+#: admin.py:329 admin.py:401 models.py:87
 msgid "Modified"
 msgstr "Modifié"
 
-#: admin.py:433 admin.py:661
+#: admin.py:437 admin.py:667
 #: templates/djangocms_versioning/admin/icons/preview.html:3
 #: templates/djangocms_versioning/admin/preview.html:3
 msgid "Preview"
 msgstr "Pré-visualisation"
 
-#: admin.py:468 admin.py:760 cms_toolbars.py:121
+#: admin.py:470 admin.py:758 cms_toolbars.py:115
 #: templates/djangocms_versioning/admin/icons/edit_icon.html:3
 msgid "Edit"
 msgstr "Éditer"
 
-#: admin.py:480
+#: admin.py:482
 #: templates/djangocms_versioning/admin/icons/manage_versions.html:3
 msgid "Manage versions"
 msgstr "Gérer les versions"
 
-#: admin.py:639
+#: admin.py:631
 msgid "Content"
 msgstr "Contenu"
 
-#: admin.py:649
+#: admin.py:647
 msgid "locked"
 msgstr "verrouillé"
 
-#: admin.py:679 templates/djangocms_versioning/admin/icons/archive_icon.html:3
+#: admin.py:683 templates/djangocms_versioning/admin/icons/archive_icon.html:3
 msgid "Archive"
 msgstr "Archiver"
 
-#: admin.py:699 cms_toolbars.py:83 indicators.py:41
+#: admin.py:701 cms_toolbars.py:79 indicators.py:34
 #: templates/djangocms_versioning/admin/icons/publish_icon.html:3
 msgid "Publish"
 msgstr "Publier"
 
-#: admin.py:721 indicators.py:61 indicators.py:67
+#: admin.py:721 indicators.py:54 indicators.py:60
 #: templates/djangocms_versioning/admin/icons/unpublish_icon.html:3
 msgid "Unpublish"
 msgstr "Dépublier"
 
-#: admin.py:760 cms_toolbars.py:121
+#: admin.py:758 cms_toolbars.py:115
 msgid "New Draft"
 msgstr "Nouveau Brouillon"
 
-#: admin.py:783 cms_toolbars.py:188
+#: admin.py:779 cms_toolbars.py:177
 #: templates/djangocms_versioning/admin/icons/revert_icon.html:3
 msgid "Revert"
 msgstr "Rétablir"
 
-#: admin.py:804 templates/djangocms_versioning/admin/icons/discard_icon.html:3
+#: admin.py:798 templates/djangocms_versioning/admin/icons/discard_icon.html:3
 msgid "Discard"
 msgstr "Rejeter"
 
-#: admin.py:829 cms_toolbars.py:153
+#: admin.py:821 cms_toolbars.py:145
 msgid "Unlock"
 msgstr "Déverrouiller"
 
 #: admin.py:856
-msgid "Exactly two versions need to be selected."
-msgstr "Il faut sélectionner exactement deux versions."
-
-#: admin.py:870
 msgid "Compare versions"
 msgstr "Comparer les versions"
 
-#: admin.py:897
+#: admin.py:866
+msgid "Exactly two versions need to be selected."
+msgstr "Il faut sélectionner exactement deux versions."
+
+#: admin.py:903
 msgid "Version cannot be archived"
 msgstr "La version ne peut pas être archivée"
 
-#: admin.py:926
+#: admin.py:929
 msgid "Version archived"
 msgstr "Version archivée"
 
-#: admin.py:937 admin.py:1059 admin.py:1241
+#: admin.py:940 admin.py:1059 admin.py:1235
 msgid "This view only supports POST method."
 msgstr "Cette vue ne prend en charge que la méthode POST."
 
-#: admin.py:948
+#: admin.py:951
 msgid "Version cannot be published"
 msgstr "La version ne peut pas être publiée"
 
-#: admin.py:959
+#: admin.py:962
 msgid "Version published"
 msgstr "Version publiée"
 
-#: admin.py:976
+#: admin.py:979
 msgid "Version cannot be unpublished"
 msgstr "La version ne peut pas être dépubliée"
 
@@ -129,19 +130,19 @@ msgstr "La version ne peut pas être dépubliée"
 msgid "Version unpublished"
 msgstr "Version non publiée"
 
-#: admin.py:1169
+#: admin.py:1163
 msgid "The last version has been deleted"
 msgstr "La dernière version a été supprimée"
 
-#: admin.py:1255
+#: admin.py:1249
 msgid "You do not have permission to remove the version lock"
 msgstr "Vous n'avez pas la permission de retirer le verrouillage de version"
 
-#: admin.py:1260
+#: admin.py:1254
 msgid "Version unlocked"
 msgstr "Version déverrouillée"
 
-#: admin.py:1309
+#: admin.py:1303
 #, python-brace-format
 msgid "Displaying versions of \"{grouper}\""
 msgstr "Afficher les versions de \"{grouper}\""
@@ -150,180 +151,180 @@ msgstr "Afficher les versions de \"{grouper}\""
 msgid "django CMS Versioning"
 msgstr "django CMS Versioning"
 
-#: cms_config.py:262
+#: cms_config.py:246
 msgid "No available title"
 msgstr "Aucun titre disponible"
 
-#: cms_config.py:264 constants.py:13 constants.py:26
+#: cms_config.py:248 constants.py:12 constants.py:25
 msgid "Unpublished"
 msgstr "Non publié"
 
-#: cms_config.py:358
+#: cms_config.py:342
 msgid "Language must be set to a supported language!"
 msgstr "La langue doit être définie comme une langue prise en charge !"
 
-#: cms_config.py:376
+#: cms_config.py:360
 msgid "You do not have permission to copy these plugins."
 msgstr "Vous n'avez pas la permission de copier ces plugins."
 
-#: cms_toolbars.py:218
+#: cms_toolbars.py:207
 msgid "Manage Versions"
 msgstr "Gérer les versions"
 
-#: cms_toolbars.py:221
+#: cms_toolbars.py:210
 #, python-brace-format
 msgid "Compare to {source}"
 msgstr "Comparer à {source}"
 
-#: cms_toolbars.py:236 indicators.py:73
+#: cms_toolbars.py:226 indicators.py:66
 msgid "Discard Changes"
 msgstr "Abandonner les modifications"
 
-#: cms_toolbars.py:271
+#: cms_toolbars.py:262
 msgid "View Published"
 msgstr "Vue publiée"
 
-#: cms_toolbars.py:327
+#: cms_toolbars.py:317
 msgid "Language"
 msgstr "Langue"
 
-#: cms_toolbars.py:374
+#: cms_toolbars.py:364
 msgid "Add Translation"
 msgstr "Ajouter une traduction"
 
-#: cms_toolbars.py:387
+#: cms_toolbars.py:377
 msgid "Copy all plugins"
 msgstr "Copier tous les plugins"
 
-#: cms_toolbars.py:389
+#: cms_toolbars.py:379
 #, python-format
 msgid "from %s"
 msgstr "de %s"
 
-#: cms_toolbars.py:390
+#: cms_toolbars.py:380
 #, python-format
 msgid "Are you sure you want to copy all plugins from %s?"
 msgstr "Êtes-vous sûr de vouloir copier tous les plugins de %s?"
 
-#: cms_toolbars.py:405
+#: cms_toolbars.py:395
 msgid "No other language available"
 msgstr "Aucune autre langue disponible"
 
-#: constants.py:11 constants.py:25
+#: constants.py:10 constants.py:24
 msgid "Draft"
 msgstr "Brouillon"
 
-#: constants.py:12 constants.py:23
+#: constants.py:11 constants.py:22
 msgid "Published"
 msgstr "Publié"
 
-#: constants.py:14 constants.py:27
+#: constants.py:13 constants.py:26
 msgid "Archived"
 msgstr "Archivé"
 
-#: constants.py:24
+#: constants.py:23
 msgid "Changed"
 msgstr "Modifié"
 
-#: emails.py:38
+#: emails.py:39
 msgid "Unlocked"
 msgstr "Déverrouillée"
 
-#: indicators.py:35
+#: indicators.py:28
 #, python-format
 msgid "Unlock (%(message)s)"
 msgstr "Déverrouiller (%(message)s)"
 
-#: indicators.py:47
+#: indicators.py:40
 msgid "Create new draft"
 msgstr "Créer un brouillon"
 
-#: indicators.py:53
+#: indicators.py:46
 msgid "Revert from Unpublish"
 msgstr "Annulation de la publication"
 
-#: indicators.py:73
+#: indicators.py:66
 msgid "Delete Draft"
 msgstr "Supprimer le brouillon"
 
-#: indicators.py:79
+#: indicators.py:72
 msgid "Compare Draft to Published..."
 msgstr "Comparer le brouillon à la version publiée..."
 
-#: indicators.py:89
+#: indicators.py:82
 msgid "Manage Versions..."
 msgstr "Gérer les versions..."
 
-#: models.py:31
+#: models.py:29
 msgid "Version is not a draft"
 msgstr "La version n'est pas un brouillon"
 
-#: models.py:32
+#: models.py:30
 #, python-brace-format
 msgid "Action Denied. The latest version is locked by {user}"
 msgstr "Action Refusée. La dernière version est verrouillée par {user}"
 
-#: models.py:33
+#: models.py:31
 #, python-brace-format
 msgid "Action Denied. The draft version is locked by {user}"
 msgstr "Action Refusée. Le brouillon est verrouillé par {user}"
 
-#: models.py:88
+#: models.py:86
 msgid "Created"
 msgstr "Créée"
 
-#: models.py:91
+#: models.py:89
 msgid "author"
 msgstr "auteur"
 
-#: models.py:100
+#: models.py:102
 msgid "status"
 msgstr "statut"
 
-#: models.py:108
+#: models.py:110
 msgid "locked by"
 msgstr "verrouillée par"
 
-#: models.py:117
+#: models.py:119
 msgid "source"
 msgstr "source"
 
-#: models.py:131
+#: models.py:133
 #, python-brace-format
 msgid "Version #{number} ({state} {date})"
 msgstr "Version #{number} ({state} {date})"
 
-#: models.py:138
+#: models.py:140
 #, python-brace-format
 msgid "Version #{number} ({state})"
 msgstr "Version #{number} ({state})"
 
-#: models.py:144
+#: models.py:146
 #, python-format
 msgid "Locked by %(user)s"
 msgstr "Verrouillée par %(user)s"
 
-#: models.py:276 models.py:325
+#: models.py:278 models.py:327
 msgid "Version is not in draft state"
 msgstr "La version n'est pas à l'état de brouillon"
 
-#: models.py:385
+#: models.py:387
 msgid "Version is not in published state"
 msgstr "La version n'est pas dans l'état publié"
 
-#: models.py:442
+#: models.py:444
 msgid "Version is not in archived or unpublished state"
 msgstr "La version n'est pas archivé ou non publié"
 
-#: models.py:457
+#: models.py:459
 msgid "Version is not in draft or published state"
 msgstr "La version n'est pas en brouillon ou publiée"
 
-#: models.py:465
+#: models.py:467
 msgid "Version is already locked"
 msgstr "La version  est déjà verrouillée"
 
-#: models.py:471
+#: models.py:473
 msgid "Draft version is not locked"
 msgstr "Le brouillon n'est pas verrouillé"
 
@@ -492,7 +493,8 @@ msgid ""
 "The following draft version has been unlocked by %(by_user)s for their use.\n"
 "%(version_link)s\n"
 "\n"
-"Please note you will not be able to further edit this draft. Kindly reach out to %(by_user)s in case of any concerns.\n"
+"Please note you will not be able to further edit this draft. Kindly reach "
+"out to %(by_user)s in case of any concerns.\n"
 "\n"
 "This is an automated notification from Django CMS.\n"
 msgstr ""
@@ -500,6 +502,7 @@ msgstr ""
 "Le brouillon suivant a été déverrouillé par %(by_user)s pour son usage.\n"
 "%(version_link)s\n"
 "\n"
-"Notez que vous ne pourrez pas continuer a modifier ce brouillon. Vous êtes prié de contacter %(by_user)s en cas de soucis.\n"
+"Notez que vous ne pourrez pas continuer a modifier ce brouillon. Vous êtes "
+"prié de contacter %(by_user)s en cas de soucis.\n"
 "\n"
 "C'est une notification automatique de Django CMS.\n"

--- a/djangocms_versioning/locale/nl/LC_MESSAGES/django.po
+++ b/djangocms_versioning/locale/nl/LC_MESSAGES/django.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-05 17:59+0200\n"
+"POT-Creation-Date: 2023-10-02 09:37+0200\n"
 "PO-Revision-Date: 2023-01-10 15:29+0000\n"
 "Last-Translator: Stefan van den Eertwegh <stefan@corebyte.nl>, 2023\n"
 "Language-Team: Dutch (https://app.transifex.com/divio/teams/58664/nl/)\n"
@@ -22,106 +22,106 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: admin.py:164 admin.py:301 admin.py:383
+#: admin.py:164 admin.py:301 admin.py:377
 msgid "State"
 msgstr "Status"
 
-#: admin.py:192 constants.py:28
+#: admin.py:192 constants.py:27
 msgid "Empty"
 msgstr "Leeg"
 
-#: admin.py:315 admin.py:395
+#: admin.py:315 admin.py:387
 msgid "Author"
 msgstr "Auteur"
 
-#: admin.py:329 admin.py:406 models.py:89
+#: admin.py:329 admin.py:401 models.py:87
 msgid "Modified"
 msgstr "Gewijzigd"
 
-#: admin.py:433 admin.py:661
+#: admin.py:437 admin.py:667
 #: templates/djangocms_versioning/admin/icons/preview.html:3
 #: templates/djangocms_versioning/admin/preview.html:3
 msgid "Preview"
 msgstr "Voorbeeld"
 
-#: admin.py:468 admin.py:760 cms_toolbars.py:121
+#: admin.py:470 admin.py:758 cms_toolbars.py:115
 #: templates/djangocms_versioning/admin/icons/edit_icon.html:3
 msgid "Edit"
 msgstr "Bewerk"
 
-#: admin.py:480
+#: admin.py:482
 #: templates/djangocms_versioning/admin/icons/manage_versions.html:3
 msgid "Manage versions"
 msgstr "Beheer versies"
 
-#: admin.py:639
+#: admin.py:631
 msgid "Content"
 msgstr "Content"
 
-#: admin.py:649
+#: admin.py:647
 msgid "locked"
 msgstr "gesloten"
 
-#: admin.py:679 templates/djangocms_versioning/admin/icons/archive_icon.html:3
+#: admin.py:683 templates/djangocms_versioning/admin/icons/archive_icon.html:3
 msgid "Archive"
 msgstr "Archiveer"
 
-#: admin.py:699 cms_toolbars.py:83 indicators.py:41
+#: admin.py:701 cms_toolbars.py:79 indicators.py:34
 #: templates/djangocms_versioning/admin/icons/publish_icon.html:3
 msgid "Publish"
 msgstr "Publiceer"
 
-#: admin.py:721 indicators.py:61 indicators.py:67
+#: admin.py:721 indicators.py:54 indicators.py:60
 #: templates/djangocms_versioning/admin/icons/unpublish_icon.html:3
 msgid "Unpublish"
 msgstr "Gedepubliceerd"
 
-#: admin.py:760 cms_toolbars.py:121
+#: admin.py:758 cms_toolbars.py:115
 msgid "New Draft"
 msgstr "Nieuw concept"
 
-#: admin.py:783 cms_toolbars.py:188
+#: admin.py:779 cms_toolbars.py:177
 #: templates/djangocms_versioning/admin/icons/revert_icon.html:3
 msgid "Revert"
 msgstr "Terugdraaien"
 
-#: admin.py:804 templates/djangocms_versioning/admin/icons/discard_icon.html:3
+#: admin.py:798 templates/djangocms_versioning/admin/icons/discard_icon.html:3
 msgid "Discard"
 msgstr "Annuleer"
 
-#: admin.py:829 cms_toolbars.py:153
+#: admin.py:821 cms_toolbars.py:145
 msgid "Unlock"
 msgstr "Ongesloten"
 
 #: admin.py:856
-msgid "Exactly two versions need to be selected."
-msgstr "Precies twee versies moeten zijn geselecteerd."
-
-#: admin.py:870
 msgid "Compare versions"
 msgstr "Vergelijk versies"
 
-#: admin.py:897
+#: admin.py:866
+msgid "Exactly two versions need to be selected."
+msgstr "Precies twee versies moeten zijn geselecteerd."
+
+#: admin.py:903
 msgid "Version cannot be archived"
 msgstr "Versie kan niet worden gearchiveerd"
 
-#: admin.py:926
+#: admin.py:929
 msgid "Version archived"
 msgstr "Versie gearchiveerd"
 
-#: admin.py:937 admin.py:1059 admin.py:1241
+#: admin.py:940 admin.py:1059 admin.py:1235
 msgid "This view only supports POST method."
 msgstr "Deze weergave ondersteunt alleen de POST methode"
 
-#: admin.py:948
+#: admin.py:951
 msgid "Version cannot be published"
 msgstr "Versie kan niet worden gepubliceerd"
 
-#: admin.py:959
+#: admin.py:962
 msgid "Version published"
 msgstr "Versie gepubliceerd"
 
-#: admin.py:976
+#: admin.py:979
 msgid "Version cannot be unpublished"
 msgstr "Versie kan niet worden gedepubliceerd"
 
@@ -129,19 +129,19 @@ msgstr "Versie kan niet worden gedepubliceerd"
 msgid "Version unpublished"
 msgstr "Versie ongepubliceerd"
 
-#: admin.py:1169
+#: admin.py:1163
 msgid "The last version has been deleted"
 msgstr "De laatste versie is verwijderd"
 
-#: admin.py:1255
+#: admin.py:1249
 msgid "You do not have permission to remove the version lock"
 msgstr "Je hebt geen rechten om de versie van t slot te halen"
 
-#: admin.py:1260
+#: admin.py:1254
 msgid "Version unlocked"
 msgstr "Versie ongesloten"
 
-#: admin.py:1309
+#: admin.py:1303
 #, python-brace-format
 msgid "Displaying versions of \"{grouper}\""
 msgstr "Weergave versies van \"{grouper}\""
@@ -150,180 +150,180 @@ msgstr "Weergave versies van \"{grouper}\""
 msgid "django CMS Versioning"
 msgstr "django CMS Versionering"
 
-#: cms_config.py:262
+#: cms_config.py:246
 msgid "No available title"
 msgstr "Geen beschikbare titel"
 
-#: cms_config.py:264 constants.py:13 constants.py:26
+#: cms_config.py:248 constants.py:12 constants.py:25
 msgid "Unpublished"
 msgstr "Ongepubliceerd"
 
-#: cms_config.py:358
+#: cms_config.py:342
 msgid "Language must be set to a supported language!"
 msgstr "Taal moet gespecificeerd worden binnen de ondersteunde talen!"
 
-#: cms_config.py:376
+#: cms_config.py:360
 msgid "You do not have permission to copy these plugins."
 msgstr "Je hebt geen rechten om deze plugin te kopieëren."
 
-#: cms_toolbars.py:218
+#: cms_toolbars.py:207
 msgid "Manage Versions"
 msgstr "Beheer versies"
 
-#: cms_toolbars.py:221
+#: cms_toolbars.py:210
 #, python-brace-format
 msgid "Compare to {source}"
 msgstr "Vergelijk met {source}"
 
-#: cms_toolbars.py:236 indicators.py:73
+#: cms_toolbars.py:226 indicators.py:66
 msgid "Discard Changes"
 msgstr "Annuleer wijzigingen"
 
-#: cms_toolbars.py:271
+#: cms_toolbars.py:262
 msgid "View Published"
 msgstr "Bekijk live versie"
 
-#: cms_toolbars.py:327
+#: cms_toolbars.py:317
 msgid "Language"
 msgstr "Taal"
 
-#: cms_toolbars.py:374
+#: cms_toolbars.py:364
 msgid "Add Translation"
 msgstr "Voeg vertaling toe"
 
-#: cms_toolbars.py:387
+#: cms_toolbars.py:377
 msgid "Copy all plugins"
 msgstr "Kopieer alle plugins"
 
-#: cms_toolbars.py:389
+#: cms_toolbars.py:379
 #, python-format
 msgid "from %s"
 msgstr "van %s"
 
-#: cms_toolbars.py:390
+#: cms_toolbars.py:380
 #, python-format
 msgid "Are you sure you want to copy all plugins from %s?"
 msgstr "Ben je er zeker van om alle plugins te kopiëren van %s?"
 
-#: cms_toolbars.py:405
+#: cms_toolbars.py:395
 msgid "No other language available"
 msgstr "Geen andere taal beschikbaar"
 
-#: constants.py:11 constants.py:25
+#: constants.py:10 constants.py:24
 msgid "Draft"
 msgstr "Concept"
 
-#: constants.py:12 constants.py:23
+#: constants.py:11 constants.py:22
 msgid "Published"
 msgstr "Gepubliceerd"
 
-#: constants.py:14 constants.py:27
+#: constants.py:13 constants.py:26
 msgid "Archived"
 msgstr "Gearchiveerd"
 
-#: constants.py:24
+#: constants.py:23
 msgid "Changed"
 msgstr "Gewijzigd"
 
-#: emails.py:38
+#: emails.py:39
 msgid "Unlocked"
 msgstr "Ongesloten"
 
-#: indicators.py:35
+#: indicators.py:28
 #, python-format
 msgid "Unlock (%(message)s)"
 msgstr "Ongesloten (%(message)s)"
 
-#: indicators.py:47
+#: indicators.py:40
 msgid "Create new draft"
 msgstr "Maakt een nieuw concept"
 
-#: indicators.py:53
+#: indicators.py:46
 msgid "Revert from Unpublish"
 msgstr "Gedepubliceerde terugdraaien"
 
-#: indicators.py:73
+#: indicators.py:66
 msgid "Delete Draft"
 msgstr "Verwijder concept"
 
-#: indicators.py:79
+#: indicators.py:72
 msgid "Compare Draft to Published..."
 msgstr "Vergelijk Concept met Gepubliceerde..."
 
-#: indicators.py:89
+#: indicators.py:82
 msgid "Manage Versions..."
 msgstr "Beheer versies..."
 
-#: models.py:31
+#: models.py:29
 msgid "Version is not a draft"
 msgstr "Versie is niet een concept"
 
-#: models.py:32
+#: models.py:30
 #, python-brace-format
 msgid "Action Denied. The latest version is locked by {user}"
 msgstr "Actie niet geldig. De laatste versie is gesloten door {user}"
 
-#: models.py:33
+#: models.py:31
 #, python-brace-format
 msgid "Action Denied. The draft version is locked by {user}"
 msgstr "Actie niet geldig. De concept versie is gesloten door {user}"
 
-#: models.py:88
+#: models.py:86
 msgid "Created"
 msgstr "Aangemaakt"
 
-#: models.py:91
+#: models.py:89
 msgid "author"
 msgstr "auteur"
 
-#: models.py:100
+#: models.py:102
 msgid "status"
 msgstr "status"
 
-#: models.py:108
+#: models.py:110
 msgid "locked by"
 msgstr "gesloten door"
 
-#: models.py:117
+#: models.py:119
 msgid "source"
 msgstr "bron"
 
-#: models.py:131
+#: models.py:133
 #, python-brace-format
 msgid "Version #{number} ({state} {date})"
 msgstr "Versie #{number} ({state} {date})"
 
-#: models.py:138
+#: models.py:140
 #, python-brace-format
 msgid "Version #{number} ({state})"
 msgstr "Versie #{number} ({state})"
 
-#: models.py:144
+#: models.py:146
 #, python-format
 msgid "Locked by %(user)s"
 msgstr "Gesloten door %(user)s"
 
-#: models.py:276 models.py:325
+#: models.py:278 models.py:327
 msgid "Version is not in draft state"
 msgstr "Versie is niet in concept staat"
 
-#: models.py:385
+#: models.py:387
 msgid "Version is not in published state"
 msgstr "Versie is niet in gepubliceerde staat"
 
-#: models.py:442
+#: models.py:444
 msgid "Version is not in archived or unpublished state"
 msgstr "Versie is niet gearchiveerd en niet gepubliceerd"
 
-#: models.py:457
+#: models.py:459
 msgid "Version is not in draft or published state"
 msgstr "Versie is niet een concept of gepubliceerde staat"
 
-#: models.py:465
+#: models.py:467
 msgid "Version is already locked"
 msgstr "Versie is al gesloten"
 
-#: models.py:471
+#: models.py:473
 msgid "Draft version is not locked"
 msgstr "Concept versie is niet gesloten"
 
@@ -492,13 +492,16 @@ msgid ""
 "The following draft version has been unlocked by %(by_user)s for their use.\n"
 "%(version_link)s\n"
 "\n"
-"Please note you will not be able to further edit this draft. Kindly reach out to %(by_user)s in case of any concerns.\n"
+"Please note you will not be able to further edit this draft. Kindly reach "
+"out to %(by_user)s in case of any concerns.\n"
 "\n"
 "This is an automated notification from Django CMS.\n"
 msgstr ""
 "\n"
-"De volgende concept versie is van het slot af door%(by_user)svoor hun gebruik.\n"
+"De volgende concept versie is van het slot af door%(by_user)svoor hun "
+"gebruik.\n"
 " %(version_link)s\n"
-"Let op: je kunt niet verder bewerken in dit concept. Neem asjeblieft contact op met %(by_user)s in geval van enige zorgen. \n"
+"Let op: je kunt niet verder bewerken in dit concept. Neem asjeblieft contact "
+"op met %(by_user)s in geval van enige zorgen. \n"
 "\n"
 "Dit is een geautomatiseerde notificatie van Django CMS.\n"

--- a/djangocms_versioning/locale/sq/LC_MESSAGES/django.po
+++ b/djangocms_versioning/locale/sq/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-05 17:59+0200\n"
+"POT-Creation-Date: 2023-10-02 09:37+0200\n"
 "PO-Revision-Date: 2023-01-10 15:29+0000\n"
 "Last-Translator: Besnik Bleta <besnik@programeshqip.org>, 2023\n"
 "Language-Team: Albanian (https://www.transifex.com/divio/teams/58664/sq/)\n"
@@ -21,108 +21,108 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: admin.py:164 admin.py:301 admin.py:383
+#: admin.py:164 admin.py:301 admin.py:377
 msgid "State"
 msgstr "Gjendje"
 
-#: admin.py:192 constants.py:28
+#: admin.py:192 constants.py:27
 msgid "Empty"
 msgstr "I zbrazët"
 
-#: admin.py:315 admin.py:395
+#: admin.py:315 admin.py:387
 msgid "Author"
 msgstr "Autor"
 
-#: admin.py:329 admin.py:406 models.py:89
+#: admin.py:329 admin.py:401 models.py:87
 msgid "Modified"
 msgstr "E ndryshuar"
 
-#: admin.py:433 admin.py:661
+#: admin.py:437 admin.py:667
 #: templates/djangocms_versioning/admin/icons/preview.html:3
 #: templates/djangocms_versioning/admin/preview.html:3
 msgid "Preview"
 msgstr "Paraparje"
 
-#: admin.py:468 admin.py:760 cms_toolbars.py:121
+#: admin.py:470 admin.py:758 cms_toolbars.py:115
 #: templates/djangocms_versioning/admin/icons/edit_icon.html:3
 msgid "Edit"
 msgstr "Përpunojeni"
 
-#: admin.py:480
+#: admin.py:482
 #: templates/djangocms_versioning/admin/icons/manage_versions.html:3
 msgid "Manage versions"
 msgstr "Administroni versione"
 
-#: admin.py:639
+#: admin.py:631
 msgid "Content"
 msgstr "Lëndë"
 
-#: admin.py:649
+#: admin.py:647
 msgid "locked"
 msgstr ""
 
-#: admin.py:679 templates/djangocms_versioning/admin/icons/archive_icon.html:3
+#: admin.py:683 templates/djangocms_versioning/admin/icons/archive_icon.html:3
 msgid "Archive"
 msgstr "Arkiv"
 
-#: admin.py:699 cms_toolbars.py:83 indicators.py:41
+#: admin.py:701 cms_toolbars.py:79 indicators.py:34
 #: templates/djangocms_versioning/admin/icons/publish_icon.html:3
 msgid "Publish"
 msgstr "Botoje"
 
-#: admin.py:721 indicators.py:61 indicators.py:67
+#: admin.py:721 indicators.py:54 indicators.py:60
 #: templates/djangocms_versioning/admin/icons/unpublish_icon.html:3
 msgid "Unpublish"
 msgstr "Hiqe nga të botuar"
 
-#: admin.py:760 cms_toolbars.py:121
+#: admin.py:758 cms_toolbars.py:115
 #, fuzzy
 #| msgid "Draft"
 msgid "New Draft"
 msgstr "Skicë"
 
-#: admin.py:783 cms_toolbars.py:188
+#: admin.py:779 cms_toolbars.py:177
 #: templates/djangocms_versioning/admin/icons/revert_icon.html:3
 msgid "Revert"
 msgstr "Riktheje"
 
-#: admin.py:804 templates/djangocms_versioning/admin/icons/discard_icon.html:3
+#: admin.py:798 templates/djangocms_versioning/admin/icons/discard_icon.html:3
 msgid "Discard"
 msgstr "Hidhe tej"
 
-#: admin.py:829 cms_toolbars.py:153
+#: admin.py:821 cms_toolbars.py:145
 msgid "Unlock"
 msgstr ""
 
 #: admin.py:856
-msgid "Exactly two versions need to be selected."
-msgstr "Lypset të përzgjidhen saktësisht dy versione."
-
-#: admin.py:870
 msgid "Compare versions"
 msgstr "Krahasoni versione"
 
-#: admin.py:897
+#: admin.py:866
+msgid "Exactly two versions need to be selected."
+msgstr "Lypset të përzgjidhen saktësisht dy versione."
+
+#: admin.py:903
 msgid "Version cannot be archived"
 msgstr "Versioni s’mund të arkivohet"
 
-#: admin.py:926
+#: admin.py:929
 msgid "Version archived"
 msgstr "Versioni u arkivua"
 
-#: admin.py:937 admin.py:1059 admin.py:1241
+#: admin.py:940 admin.py:1059 admin.py:1235
 msgid "This view only supports POST method."
 msgstr "Kjo pamje mbulon vetëm metodën POST."
 
-#: admin.py:948
+#: admin.py:951
 msgid "Version cannot be published"
 msgstr "Versioni s’mund të botohet"
 
-#: admin.py:959
+#: admin.py:962
 msgid "Version published"
 msgstr "Versioni u botua"
 
-#: admin.py:976
+#: admin.py:979
 msgid "Version cannot be unpublished"
 msgstr "Versioni s’mund të shbotohet"
 
@@ -130,23 +130,23 @@ msgstr "Versioni s’mund të shbotohet"
 msgid "Version unpublished"
 msgstr "Versioni u shbotua"
 
-#: admin.py:1169
+#: admin.py:1163
 msgid "The last version has been deleted"
 msgstr "Versioni i fundit është fshirë"
 
-#: admin.py:1255
+#: admin.py:1249
 #, fuzzy
 #| msgid "You do not have permission to copy these plugins."
 msgid "You do not have permission to remove the version lock"
 msgstr "S’keni leje të kopjoni këto shtojca."
 
-#: admin.py:1260
+#: admin.py:1254
 #, fuzzy
 #| msgid "Version unpublished"
 msgid "Version unlocked"
 msgstr "Versioni u shbotua"
 
-#: admin.py:1309
+#: admin.py:1303
 #, python-brace-format
 msgid "Displaying versions of \"{grouper}\""
 msgstr "Po shfaqen versione të “{grouper}”"
@@ -155,187 +155,187 @@ msgstr "Po shfaqen versione të “{grouper}”"
 msgid "django CMS Versioning"
 msgstr "Versione në django CMS"
 
-#: cms_config.py:262
+#: cms_config.py:246
 msgid "No available title"
 msgstr "S’ka titull"
 
-#: cms_config.py:264 constants.py:13 constants.py:26
+#: cms_config.py:248 constants.py:12 constants.py:25
 msgid "Unpublished"
 msgstr "I pabotuar"
 
-#: cms_config.py:358
+#: cms_config.py:342
 msgid "Language must be set to a supported language!"
 msgstr "Si gjuhë duhet të caktoni një gjuhë të mbuluar!"
 
-#: cms_config.py:376
+#: cms_config.py:360
 msgid "You do not have permission to copy these plugins."
 msgstr "S’keni leje të kopjoni këto shtojca."
 
-#: cms_toolbars.py:218
+#: cms_toolbars.py:207
 msgid "Manage Versions"
 msgstr "Administroni Versione"
 
-#: cms_toolbars.py:221
+#: cms_toolbars.py:210
 #, fuzzy, python-brace-format
 #| msgid "Compare to {state} source"
 msgid "Compare to {source}"
 msgstr "Krahasoje me burimin {state}"
 
-#: cms_toolbars.py:236 indicators.py:73
+#: cms_toolbars.py:226 indicators.py:66
 #, fuzzy
 #| msgid "Discard"
 msgid "Discard Changes"
 msgstr "Hidhe tej"
 
-#: cms_toolbars.py:271
+#: cms_toolbars.py:262
 msgid "View Published"
 msgstr "Shihni të Botuarin"
 
-#: cms_toolbars.py:327
+#: cms_toolbars.py:317
 msgid "Language"
 msgstr "Gjuhë"
 
-#: cms_toolbars.py:374
+#: cms_toolbars.py:364
 msgid "Add Translation"
 msgstr "Shtoni Përkthim"
 
-#: cms_toolbars.py:387
+#: cms_toolbars.py:377
 msgid "Copy all plugins"
 msgstr "Kopjo krejt shtojcat"
 
-#: cms_toolbars.py:389
+#: cms_toolbars.py:379
 #, python-format
 msgid "from %s"
 msgstr "prej %s"
 
-#: cms_toolbars.py:390
+#: cms_toolbars.py:380
 #, python-format
 msgid "Are you sure you want to copy all plugins from %s?"
 msgstr "Jeni i sigurt se doni të kopjohen krejt shtojcat prej %s?"
 
-#: cms_toolbars.py:405
+#: cms_toolbars.py:395
 msgid "No other language available"
 msgstr "S’ka gjuhë të tjera"
 
-#: constants.py:11 constants.py:25
+#: constants.py:10 constants.py:24
 msgid "Draft"
 msgstr "Skicë"
 
-#: constants.py:12 constants.py:23
+#: constants.py:11 constants.py:22
 msgid "Published"
 msgstr "I botuar"
 
-#: constants.py:14 constants.py:27
+#: constants.py:13 constants.py:26
 msgid "Archived"
 msgstr "I arkivuar"
 
-#: constants.py:24
+#: constants.py:23
 msgid "Changed"
 msgstr "I ndryshur"
 
-#: emails.py:38
+#: emails.py:39
 msgid "Unlocked"
 msgstr ""
 
-#: indicators.py:35
+#: indicators.py:28
 #, python-format
 msgid "Unlock (%(message)s)"
 msgstr ""
 
-#: indicators.py:47
+#: indicators.py:40
 msgid "Create new draft"
 msgstr "Krijoni një skicë të re"
 
-#: indicators.py:53
+#: indicators.py:46
 msgid "Revert from Unpublish"
 msgstr "Riktheje nga Shbotoje"
 
-#: indicators.py:73
+#: indicators.py:66
 msgid "Delete Draft"
 msgstr "Fshije Skicën"
 
-#: indicators.py:79
+#: indicators.py:72
 msgid "Compare Draft to Published..."
 msgstr "Krahaso Skicë me të Pabotuar…"
 
-#: indicators.py:89
+#: indicators.py:82
 msgid "Manage Versions..."
 msgstr "Administroni Versione…"
 
-#: models.py:31
+#: models.py:29
 msgid "Version is not a draft"
 msgstr "Versioni s’është skicë"
 
-#: models.py:32
+#: models.py:30
 #, python-brace-format
 msgid "Action Denied. The latest version is locked by {user}"
 msgstr ""
 
-#: models.py:33
+#: models.py:31
 #, python-brace-format
 msgid "Action Denied. The draft version is locked by {user}"
 msgstr ""
 
-#: models.py:88
+#: models.py:86
 #, fuzzy
 #| msgid "Create new draft"
 msgid "Created"
 msgstr "Krijoni një skicë të re"
 
-#: models.py:91
+#: models.py:89
 msgid "author"
 msgstr "autor"
 
-#: models.py:100
+#: models.py:102
 msgid "status"
 msgstr "gjendje"
 
-#: models.py:108
+#: models.py:110
 msgid "locked by"
 msgstr ""
 
-#: models.py:117
+#: models.py:119
 msgid "source"
 msgstr "burim"
 
-#: models.py:131
+#: models.py:133
 #, python-brace-format
 msgid "Version #{number} ({state} {date})"
 msgstr "Version #{number} ({state} {date})"
 
-#: models.py:138
+#: models.py:140
 #, python-brace-format
 msgid "Version #{number} ({state})"
 msgstr "Version #{number} ({state})"
 
-#: models.py:144
+#: models.py:146
 #, python-format
 msgid "Locked by %(user)s"
 msgstr ""
 
-#: models.py:276 models.py:325
+#: models.py:278 models.py:327
 msgid "Version is not in draft state"
 msgstr "Versioni s’është nën gjendjen “skicë”"
 
-#: models.py:385
+#: models.py:387
 msgid "Version is not in published state"
 msgstr "Versioni s’është nën gjendjen “i botuar”"
 
-#: models.py:442
+#: models.py:444
 msgid "Version is not in archived or unpublished state"
 msgstr "Versioni s’është nën gjendjen “i arkivuar” ose “i pabotuar”"
 
-#: models.py:457
+#: models.py:459
 msgid "Version is not in draft or published state"
 msgstr "Versioni s’është nën gjendjen “skicë” ose “i botuar”"
 
-#: models.py:465
+#: models.py:467
 #, fuzzy
 #| msgid "Version archived"
 msgid "Version is already locked"
 msgstr "Versioni u arkivua"
 
-#: models.py:471
+#: models.py:473
 #, fuzzy
 #| msgid "Version is not a draft"
 msgid "Draft version is not locked"

--- a/tests/requirements/requirements_base.txt
+++ b/tests/requirements/requirements_base.txt
@@ -2,9 +2,8 @@ beautifulsoup4
 coverage
 django-app-helper
 factory-boy
-flake8
+ruff
 freezegun
-isort
 lxml
 mock
 pillow

--- a/tests/requirements/requirements_base.txt
+++ b/tests/requirements/requirements_base.txt
@@ -11,6 +11,7 @@ pyflakes>=2.1.1
 python-dateutil
 mysqlclient==2.0.3
 psycopg2
+setuptools
 
 djangocms-text-ckeditor>=5.1.2
 # Unreleased django-cms 4.0 compatible packages

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -388,10 +388,7 @@ class VersionAdminTestCase(CMSTestCase):
         The link returned is the change url for an editable object
         """
         version = factories.PageVersionFactory(content__title="mypage")
-        preview_url = admin_reverse(
-            "cms_placeholder_render_object_preview",
-            args=(version.content_type_id, version.object_id),
-        )
+        preview_url = helpers.get_preview_url(version.content)
         self.assertEqual(
             self.site._registry[Version].content_link(version),
             f'<a target="_top" class="js-close-sideframe" href="{preview_url}">{version.content}</a>',
@@ -432,7 +429,7 @@ class VersionAdminTestCase(CMSTestCase):
             self.assertEqual(
                 self.site._registry[Version].content_link(version),
                 '<a target="_top" class="js-close-sideframe" href="{url}">{label}</a>'.format(
-                    url=get_object_preview_url(version.content),
+                    url=get_object_preview_url(version.content, language=version.content.language),
                     label=version.content
                 ),
             )
@@ -2019,10 +2016,7 @@ class CompareViewTestCase(CMSTestCase):
         self.assertIn("v1", context)
         self.assertEqual(context["v1"], versions[0])
         self.assertIn("v1_preview_url", context)
-        v1_preview_url = reverse(
-            "admin:cms_placeholder_render_object_preview",
-            args=(versions[0].content_type_id, versions[0].object_id),
-        )
+        v1_preview_url = helpers.get_preview_url(versions[0].content)
         parsed = urlparse(context["v1_preview_url"])
         self.assertEqual(parsed.path, v1_preview_url)
         self.assertEqual(
@@ -2074,10 +2068,7 @@ class CompareViewTestCase(CMSTestCase):
         self.assertIn("v1", context)
         self.assertEqual(context["v1"], versions[0])
         self.assertIn("v1_preview_url", context)
-        v1_preview_url = reverse(
-            "admin:cms_placeholder_render_object_preview",
-            args=(versions[0].content_type_id, versions[0].object_id),
-        )
+        v1_preview_url = helpers.get_preview_url(versions[0].content)
         parsed = urlparse(context["v1_preview_url"])
         self.assertEqual(parsed.path, v1_preview_url)
         self.assertEqual(
@@ -2087,10 +2078,7 @@ class CompareViewTestCase(CMSTestCase):
         self.assertIn("v2", context)
         self.assertEqual(context["v2"], versions[1])
         self.assertIn("v2_preview_url", context)
-        v2_preview_url = reverse(
-            "admin:cms_placeholder_render_object_preview",
-            args=(versions[1].content_type_id, versions[1].object_id),
-        )
+        v2_preview_url = helpers.get_preview_url(versions[1].content)
         parsed = urlparse(context["v2_preview_url"])
         self.assertEqual(parsed.path, v2_preview_url)
         self.assertEqual(

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -440,6 +440,14 @@ class VersionAdminActionsTestCase(CMSTestCase):
         self.versionable = PollsCMSConfig.versioning[0]
         self.version_admin = admin.site._registry[self.versionable.version_model_proxy]
 
+
+    def test_get_preview_url(self):
+        content = factories.PollContentWithVersionFactory(language="fr")
+        self.assertEqual(
+            helpers.get_preview_url(content, language="en"),
+            helpers.get_preview_url(content, language="fr"),
+        )
+
     def test_edit_action_link_enabled_state(self):
         """
         The edit action is active, a user can follow a link
@@ -3072,3 +3080,4 @@ class ListActionsTestCase(CMSTestCase):
             response = self.client.get(changelist + "?back=/hijack_url")
             self.assertNotContains(response, "hijack_url")
             self.assertContains(response, version_list_url(version.content))
+

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -25,6 +25,7 @@ from django.test.utils import ignore_warnings
 from django.urls import reverse
 from django.utils.http import urlencode
 from django.utils.timezone import now
+from django.utils.translation import override
 from freezegun import freeze_time
 
 import djangocms_versioning.helpers
@@ -426,13 +427,14 @@ class VersionAdminTestCase(CMSTestCase):
         """
         version = factories.PageVersionFactory(content__title="test5")
         with patch.object(helpers, "is_editable_model", return_value=True):
-            self.assertEqual(
-                self.site._registry[Version].content_link(version),
-                '<a target="_top" class="js-close-sideframe" href="{url}">{label}</a>'.format(
-                    url=get_object_preview_url(version.content, language=version.content.language),
-                    label=version.content
-                ),
-            )
+            with override(version.content.language):
+                self.assertEqual(
+                    self.site._registry[Version].content_link(version),
+                    '<a target="_top" class="js-close-sideframe" href="{url}">{label}</a>'.format(
+                        url=get_object_preview_url(version.content, language=version.content.language),
+                        label=version.content
+                    ),
+                )
 
 
 class VersionAdminActionsTestCase(CMSTestCase):

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -440,14 +440,6 @@ class VersionAdminActionsTestCase(CMSTestCase):
         self.versionable = PollsCMSConfig.versioning[0]
         self.version_admin = admin.site._registry[self.versionable.version_model_proxy]
 
-
-    def test_get_preview_url(self):
-        content = factories.PollContentWithVersionFactory(language="fr")
-        self.assertEqual(
-            helpers.get_preview_url(content, language="en"),
-            helpers.get_preview_url(content, language="fr"),
-        )
-
     def test_edit_action_link_enabled_state(self):
         """
         The edit action is active, a user can follow a link

--- a/tests/test_locking.py
+++ b/tests/test_locking.py
@@ -749,7 +749,7 @@ class VersionToolbarOverrideTestCase(CMSTestCase):
         self.user_has_change_perms = self._create_user(
             "user_default_perms",
             is_staff=True,
-            permissions=["change_page", "add_page", "publish_page", "delete_page"],
+            permissions=["change_page", "add_page", "delete_page"],
         )
         # Grant permission (or Unlock button will not be shown)
         GlobalPagePermission.objects.create(

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,7 @@
 [tox]
 envlist =
-    flake8
-    isort
-    py{39.310,311}-dj{32,40,41}-sqlite
+    ruff
+    py{39.310,311}-dj{32,40,41,42}-sqlite
 
 skip_missing_interpreters=True
 
@@ -13,11 +12,12 @@ deps =
     dj32: -r{toxinidir}/tests/requirements/dj32_cms41.txt
     dj40: -r{toxinidir}/tests/requirements/dj40_cms41.txt
     dj41: -r{toxinidir}/tests/requirements/dj41_cms41.txt
+    dj42: -r{toxinidir}/tests/requirements/dj42_cms41.txt
 
 basepython =
     py39: python3.9
     py310: python3.10
-    py311: python3.10
+    py311: python3.11
 
 commands =
     {envpython} --version
@@ -25,10 +25,9 @@ commands =
     {env:COMMAND:coverage} run setup.py test
     {env:COMMAND:coverage} report
 
-[testenv:flake8]
-commands = flake8
-basepython = python3.9
+[testenv:ruff]
+commands =
+    ruff {toxinidir}/djangocms_versioning
+    ruff {toxinidir}/tests
 
-[testenv:isort]
-commands = isort --check-only --diff {toxinidir}/djangocms_versioning
-basepython = python3.9
+basepython = python3.11


### PR DESCRIPTION
## Description

This PR fixes an issue with the preview links falling back to the primary language.

* No more jumping between languages when clicking preview in the version admin
* Comparing pages not of the primary language works

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
