### PR TITLE
#336 bugfix from link_menu_item to modal_menu_item: discard changes link

### DIFF
--- a/djangocms_versioning/cms_toolbars.py
+++ b/djangocms_versioning/cms_toolbars.py
@@ -222,7 +222,7 @@ class VersioningToolbar(PlaceholderToolbar):
                 # Discard changes menu entry (wrt to source)
                 if version.check_discard.as_bool(self.request.user):  # pragma: no cover
                     versioning_menu.add_item(Break())
-                    versioning_menu.add_link_item(
+                    versioning_menu.add_modal_item(
                         _("Discard Changes"),
                         url=reverse(
                             f"admin:{proxy_model._meta.app_label}_{proxy_model.__name__.lower()}_discard",


### PR DESCRIPTION
## Description

The 'discard changes' link in the versioning menu item (toolbar) is with this PR changed from add_link_item to add_modal_item.

* [v ] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
