### PR TITLE
fix: No unlock button for published content, edit preview button for locked versions

### DIFF
--- a/djangocms_versioning/admin.py
+++ b/djangocms_versioning/admin.py
@@ -655,8 +655,8 @@ class VersionAdmin(ChangeListActionsMixin, admin.ModelAdmin, metaclass=MediaDefi
         return ""
 
     def _get_preview_link(self, obj, request):
-        if obj.state == DRAFT and not obj.locked_by:
-            # Draft versions have edit button
+        if obj.state == DRAFT and obj.check_edit_redirect.as_bool(request.user):
+            # Draft versions might have edit button
             return ""
         url = get_preview_url(obj.content)
         return self.admin_action_button(

--- a/djangocms_versioning/admin.py
+++ b/djangocms_versioning/admin.py
@@ -655,7 +655,7 @@ class VersionAdmin(ChangeListActionsMixin, admin.ModelAdmin, metaclass=MediaDefi
         return ""
 
     def _get_preview_link(self, obj, request):
-        if obj.state == DRAFT:
+        if obj.state == DRAFT and not obj.locked_by:
             # Draft versions have edit button
             return ""
         url = get_preview_url(obj.content)

--- a/djangocms_versioning/models.py
+++ b/djangocms_versioning/models.py
@@ -475,7 +475,7 @@ class Version(models.Model):
     )
     check_unlock = Conditions(
         [
-            in_state([constants.DRAFT, constants.PUBLISHED], not_draft_error),
+            in_state([constants.DRAFT], not_draft_error),
             draft_is_locked(_("Draft version is not locked"))
         ]
     )

--- a/docs/version_locking.rst
+++ b/docs/version_locking.rst
@@ -1,31 +1,38 @@
 .. _locking-versions:
 
-****************
 Locking versions
-****************
+================
 
 Explanation
 -----------
-The lock versions setting is intended to modify the way djangocms-versioning works in the following way:
+
+The lock versions setting is intended to modify the way djangocms-versioning works in
+the following way:
 
 - A version is **locked to its author** when a draft is created.
 - The lock prevents editing of the draft by anyone other than the author.
 - That version becomes automatically unlocked again once it is published.
 - Locks can be removed by a user with the correct permission (``delete_versionlock``)
 - Unlocking an item sends an email notification to the author to which it was locked.
-- Manually unlocking a version does not lock it to the unlocking user, nor does it change the author.
-- The Version admin view for each versioned content-type shows lock icons and offers unlock actions
+- Manually unlocking a version does not lock it to the unlocking user, nor does it
+  change the author.
+- The Version admin view for each versioned content-type shows lock icons and offers
+  unlock actions
 
 Activation
 ----------
-In your project's ``settings.py`` add::
+
+In your project's ``settings.py`` add:
+
+.. code-block::
 
     DJANGOCMS_VERSIONING_LOCK_VERSIONS = True
 
-
-
 Email notifications
-------------------------
-Configure email notifications to fail silently by setting::
+-------------------
+
+Configure email notifications to fail silently by setting:
+
+.. code-block::
 
     EMAIL_NOTIFICATIONS_FAIL_SILENTLY = True


### PR DESCRIPTION
## Description

This PR resolves a problem where the unlock button on a published version (where unlocking does not make sense).

It also adds a preview button to a locked version in the version change list.

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
