### PR TITLE
fix: For Django CMS 4.1.1 and later do not automatically register versioned CMS Menu

### DIFF
--- a/djangocms_versioning/admin.py
+++ b/djangocms_versioning/admin.py
@@ -1316,10 +1316,7 @@ class VersionAdmin(ChangeListActionsMixin, admin.ModelAdmin, metaclass=MediaDefi
             # Check if custom breadcrumb template defined, otherwise
             # fallback on default
             breadcrumb_templates = [
-                "admin/djangocms_versioning/{app_label}/{model_name}/versioning_breadcrumbs.html".format(
-                    app_label=breadcrumb_opts.app_label,
-                    model_name=breadcrumb_opts.model_name,
-                ),
+                f"admin/djangocms_versioning/{breadcrumb_opts.app_label}/{breadcrumb_opts.model_name}/versioning_breadcrumbs.html",
                 "admin/djangocms_versioning/versioning_breadcrumbs.html",
             ]
             extra_context["breadcrumb_template"] = select_template(breadcrumb_templates)

--- a/djangocms_versioning/cms_toolbars.py
+++ b/djangocms_versioning/cms_toolbars.py
@@ -125,8 +125,8 @@ class VersioningToolbar(PlaceholderToolbar):
         if LOCK_VERSIONS and self._is_versioned():
             item = ButtonList(side=self.toolbar.RIGHT)
             proxy_model = self._get_proxy_model()
-            version = Version.objects.get_for_content(self.toolbar.obj)
-            if version.check_unlock.as_bool(self.request.user):
+            version = Version.objects.filter_by_content_grouping_values(self.toolbar.obj).filter(state=DRAFT).first()
+            if version and version.check_unlock.as_bool(self.request.user):
                 unlock_url = reverse(
                     f"admin:{proxy_model._meta.app_label}_{proxy_model.__name__.lower()}_unlock",
                     args=(version.pk,),

--- a/djangocms_versioning/conf.py
+++ b/djangocms_versioning/conf.py
@@ -1,7 +1,8 @@
+from cms import __version__ as CMS_VERSION
 from django.conf import settings
 
 ENABLE_MENU_REGISTRATION = getattr(
-    settings, "DJANGOCMS_VERSIONING_ENABLE_MENU_REGISTRATION", True
+    settings, "DJANGOCMS_VERSIONING_ENABLE_MENU_REGISTRATION", CMS_VERSION <= "4.1.0"
 )
 
 USERNAME_FIELD = getattr(

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -25,10 +25,12 @@ Settings for djangocms Versioning
 
 .. py:attribute:: DJANGOCMS_VERSIONING_ENABLE_MENU_REGISTRATION
 
-    Defaults to ``True``
+    Defaults to ``True`` (for django CMS <= 4.1.0) and ``False``
+    (for django CMS > 4.1.0)
 
     This settings specifies if djangocms-versioning should register its own
-    versioned CMS menu.
+    versioned CMS menu. This is necessary for CMS <= 4.1.0. For CMS > 4.1.0, the
+    django CMS core comes with a version-ready menu.
 
     The versioned CMS menu also shows draft content in edit and preview mode.
 


### PR DESCRIPTION
## Description

As of django CMS 4.1.1, the django CMS core comes with a versioning-ready CMS Menu which
* is significantly faster than the CMS Menu provided by djangocms-versioning
* behaves as documented regarding fallback languages

This PR changes the default value of the setting `DJANGOCMS_VERSIONING_ENABLE_MENU_REGISTRATION` from `True` (CMS <= 4.1.0) to `False`.

Projects which set  `DJANGOCMS_VERSIONING_ENABLE_MENU_REGISTRATION`  are not affected by this PR.

Projects relying on the default setting will switch back to the faster CMS Menu of the django CMS core if at least version 4.1.1 is installed.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* https://github.com/django-cms/django-cms/pull/7807
* #379 

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
