### PR TITLE
code cleanup by removing redundancy

### DIFF
--- a/djangocms_versioning/cms_config.py
+++ b/djangocms_versioning/cms_config.py
@@ -231,7 +231,7 @@ def copy_page_content(original_content):
         if hasattr(original_content, field.name):
             extension = getattr(original_content, field.name)
             if isinstance(extension, BaseExtension):
-                extension.copy(new_content, new_content.language)
+                extension.copy(new_content)
 
     return new_content
 


### PR DESCRIPTION
## Description

should be rewritten as `extension.copy(new_content)` because language is redundant in this context, aka. `PageContent` already knows its language.

* [x] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
