### PR TITLE
fix: Avoid unnecessary loading of `actions.js` asset into the toolbar

### DIFF
--- a/djangocms_versioning/cms_toolbars.py
+++ b/djangocms_versioning/cms_toolbars.py
@@ -35,9 +35,6 @@ VERSIONING_MENU_IDENTIFIER = "version"
 
 
 class VersioningToolbar(PlaceholderToolbar):
-    class Media:
-        js = ("cms/js/admin/actions.js",)
-
     def _get_versionable(self):
         """Helper method to get the versionable for the content type
         of the version
@@ -79,7 +76,7 @@ class VersioningToolbar(PlaceholderToolbar):
                 _("Publish"),
                 url=publish_url,
                 disabled=False,
-                extra_classes=["cms-btn-action", "js-action", "cms-form-post-method", "cms-versioning-js-publish-btn"],
+                extra_classes=["cms-btn-action", "cms-form-post-method", "cms-versioning-js-publish-btn"],
             )
             self.toolbar.add_item(item)
 
@@ -115,7 +112,7 @@ class VersioningToolbar(PlaceholderToolbar):
                 _("Edit") if draft_exists else _("New Draft"),
                 url=edit_url,
                 disabled=disabled,
-                extra_classes=["cms-btn-action", "js-action", "cms-form-post-method", "cms-versioning-js-edit-btn"],
+                extra_classes=["cms-btn-action", "cms-form-post-method", "cms-versioning-js-edit-btn"],
             )
             self.toolbar.add_item(item)
 
@@ -135,7 +132,6 @@ class VersioningToolbar(PlaceholderToolbar):
                 if can_unlock:
                     extra_classes = [
                         "cms-btn-action",
-                        "js-action",
                         "cms-form-post-method",
                         "cms-versioning-js-unlock-btn",
                     ]
@@ -316,7 +312,7 @@ class VersioningPageToolbar(PageToolbar):
         # Only override the menu if it exists and a page can be found
         language_menu = self.toolbar.get_menu(LANGUAGE_MENU_IDENTIFIER, _("Language"))
         if settings.USE_I18N and language_menu and self.page:
-            # remove_item uses `items` attribute so we have to copy object
+            # remove_item uses `items` attribute, so we have to copy object
             for _item in copy(language_menu.items):
                 language_menu.remove_item(item=_item)
 

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@ from setuptools import find_packages, setup
 import djangocms_versioning
 
 INSTALL_REQUIREMENTS = [
-    "Django>=1.11",
-    "django-cms",
+    "Django>=3.2",
+    "django-cms>=4.1.1",
     "django-fsm"
 ]
 

--- a/tests/test_toolbars.py
+++ b/tests/test_toolbars.py
@@ -65,7 +65,7 @@ class VersioningToolbarTestCase(CMSTestCase):
         self.assertFalse(publish_button.disabled)
         self.assertListEqual(
             publish_button.extra_classes,
-            ["cms-btn-action", "js-action", "cms-form-post-method", "cms-versioning-js-publish-btn"],
+            ["cms-btn-action", "cms-form-post-method", "cms-versioning-js-publish-btn"],
         )
 
     def test_revert_in_toolbar_in_preview_mode(self):
@@ -150,7 +150,7 @@ class VersioningToolbarTestCase(CMSTestCase):
         self.assertFalse(edit_button.disabled)
         self.assertListEqual(
             edit_button.extra_classes,
-            ["cms-btn-action", "js-action", "cms-form-post-method", "cms-versioning-js-edit-btn"]
+            ["cms-btn-action", "cms-form-post-method", "cms-versioning-js-edit-btn"]
         )
 
     def test_edit_not_in_toolbar_in_edit_mode(self):


### PR DESCRIPTION

## Description
As of django CMS 4.1.1, the `actions.js` asset needs not be loaded by the toolbar.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #402 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
