### PR TITLE
fix: Do not show edit action for version objects where editing is not possible

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,4 +14,4 @@ jobs:
     - run: python -Im pip install --user ruff
 
     - name: Run ruff
-      run: ruff --output-format=github djangocms_versioning tests
+      run: ruff check --output-format=github djangocms_versioning tests

--- a/djangocms_versioning/admin.py
+++ b/djangocms_versioning/admin.py
@@ -491,7 +491,7 @@ class ExtendedVersionAdminMixin(
         actions = [
             self._get_preview_link,
             self._get_edit_link,
-         ]
+        ]
         if "state_indicator" not in self.versioning_list_display:
             # State indicator mixin loaded?
             actions.append(self._get_manage_versions_link)
@@ -729,6 +729,10 @@ class VersionAdmin(ChangeListActionsMixin, admin.ModelAdmin, metaclass=MediaDefi
     def _get_edit_link(self, obj, request, disabled=False):
         """Helper function to get the html link to the edit action
         """
+
+        if not obj.check_edit_redirect.as_bool(request.user):
+            return ""
+
         # Only show if no draft exists
         if obj.state == PUBLISHED:
             pks_for_grouper = obj.versionable.for_content_grouping_values(
@@ -758,7 +762,7 @@ class VersionAdmin(ChangeListActionsMixin, admin.ModelAdmin, metaclass=MediaDefi
             title=_("Edit") if icon == "pencil" else _("New Draft"),
             name="edit",
             action="post",
-            disabled=not obj.check_edit_redirect.as_bool(request.user) or disabled,
+            disabled=disabled,
             keepsideframe=keepsideframe,
         )
 

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -528,9 +528,9 @@ class VersionAdminActionsTestCase(CMSTestCase):
             'cms-action-revert '
             'js-action '
             'js-keep-sideframe" '
-            'href="%s" '
+            f'href="{draft_revert_url}" '
             'title="Revert">'
-        ) % draft_revert_url
+        )
         self.assertIn(expected_enabled_state, actual_enabled_control.replace("\n", ""))
 
     def test_revert_action_link_for_draft_state(self):
@@ -599,9 +599,9 @@ class VersionAdminActionsTestCase(CMSTestCase):
             'cms-action-discard '
             'js-action '
             'js-keep-sideframe" '
-            'href="%s" '
+            f'href="{draft_discard_url}" '
             'title="Discard">'
-        ) % draft_discard_url
+        )
         self.assertIn(expected_enabled_state, actual_enabled_control.replace("\n", ""))
 
     def test_discard_action_link_for_archive_state(self):
@@ -664,11 +664,11 @@ class VersionAdminActionsTestCase(CMSTestCase):
             'cms-action-revert '
             'js-action '
             'js-keep-sideframe" '
-            'href="%s" '
+            f'href="{draft_revert_url}" '
             'title="Revert">'
             '<span class="cms-icon cms-icon-undo"></span>'
             '</a>'
-        ) % draft_revert_url
+        )
 
         self.assertIn(
             expected_disabled_control, actual_disabled_control.replace("\n", "")

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -117,7 +117,7 @@ class ExtensionTestCase(CMSTestCase):
         poll_extension = PollTitleExtensionFactory(extended_object=self.version.content)
         model_site = PollExtensionAdmin(admin_site=admin.AdminSite(), model=PollPageContentExtension)
         test_url = admin_reverse("extended_polls_pollpagecontentextension_change", args=(poll_extension.pk,))
-        test_url += "?extended_object=%s" % self.version.content.pk
+        test_url += f"?extended_object={self.version.content.pk}"
         request = RequestFactory().post(path=test_url)
         request.user = self.get_superuser()
 
@@ -137,7 +137,7 @@ class ExtensionTestCase(CMSTestCase):
         model_site = PollExtensionAdmin(admin_site=admin.AdminSite(), model=PollPageContentExtension)
         pre_changes_date_modified = Version.objects.get(id=self.version.pk).modified
         test_url = admin_reverse("extended_polls_pollpagecontentextension_change", args=(poll_extension.pk,))
-        test_url += "?extended_object=%s" % self.version.content.pk
+        test_url += f"?extended_object={self.version.content.pk}"
 
         request = RequestFactory().post(path=test_url)
         request.user = self.get_superuser()
@@ -155,7 +155,7 @@ class ExtensionTestCase(CMSTestCase):
         with self.login_user_context(self.get_superuser()):
             response = self.client.get(
                 admin_reverse("extended_polls_pollpagecontentextension_add") +
-                "?extended_object=%s" % self.version.content.pk,
+                f"?extended_object={self.version.content.pk}",
                 follow=True
             )
             self.assertEqual(response.status_code, 200)

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -7,7 +7,6 @@ from freezegun import freeze_time
 
 from djangocms_versioning.models import Version
 from djangocms_versioning.test_utils import factories
-from djangocms_versioning.test_utils.factories import PageUrlFactory
 
 
 class HandlersTestCase(CMSTestCase):

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -7,6 +7,7 @@ from freezegun import freeze_time
 
 from djangocms_versioning.models import Version
 from djangocms_versioning.test_utils import factories
+from djangocms_versioning.test_utils.factories import PageUrlFactory
 
 
 class HandlersTestCase(CMSTestCase):
@@ -21,6 +22,7 @@ class HandlersTestCase(CMSTestCase):
     def test_add_plugin(self):
         version = factories.PageVersionFactory()
         placeholder = factories.PlaceholderFactory(source=version.content)
+        placeholder.page.get_absolute_url = lambda *args, **kwargs: "/test_page/"  # Fake URL needed for URI
         poll = factories.PollFactory()
         dt = datetime(2016, 6, 6)
         with freeze_time(dt):
@@ -45,6 +47,7 @@ class HandlersTestCase(CMSTestCase):
         plugin = add_plugin(
             placeholder, "PollPlugin", version.content.language, poll=poll
         )
+        plugin.page.get_absolute_url = lambda *args, **kwargs: "/test_page/"  # Fake URL needed for URI
 
         dt = datetime(2016, 6, 6)
         with freeze_time(dt):
@@ -61,6 +64,7 @@ class HandlersTestCase(CMSTestCase):
     def test_clear_placeholder(self):
         version = factories.PageVersionFactory()
         placeholder = factories.PlaceholderFactory(source=version.content)
+        placeholder.page.get_absolute_url = lambda *args, **kwargs: "/test_page/"  # Fake URL needed for URI
 
         dt = datetime(2016, 6, 6)
         with freeze_time(dt):
@@ -81,6 +85,7 @@ class HandlersTestCase(CMSTestCase):
         plugin = add_plugin(
             placeholder, "PollPlugin", version.content.language, poll=poll
         )
+        plugin.page.get_absolute_url = lambda *args, **kwargs: "/test_page/"  # Fake URL needed for URI
 
         dt = datetime(2016, 6, 6)
         with freeze_time(dt):
@@ -103,6 +108,7 @@ class HandlersTestCase(CMSTestCase):
         plugin = add_plugin(
             source_placeholder, "PollPlugin", version.content.language, poll=poll
         )
+        plugin.page.get_absolute_url = lambda *args, **kwargs: "/test_page/"  # Fake URL needed for URI
 
         dt = datetime(2016, 6, 6)
         with freeze_time(dt):
@@ -165,7 +171,7 @@ class HandlersTestCase(CMSTestCase):
         plugin = add_plugin(
             source_placeholder, "PollPlugin", version.content.language, poll=poll
         )
-
+        plugin.page.get_absolute_url = lambda *args, **kwargs: "/test_page/"
         dt = datetime(2016, 6, 6)
         with freeze_time(dt):
             endpoint = self.get_move_plugin_uri(plugin)
@@ -197,6 +203,7 @@ class HandlersTestCase(CMSTestCase):
         plugin = add_plugin(
             placeholder, "PollPlugin", version.content.language, poll=poll
         )
+        plugin.page.get_absolute_url = lambda *args, **kwargs: "/test_page/"  # Fake URL needed for URI
 
         dt = datetime(2016, 6, 6)
         with freeze_time(dt):
@@ -223,6 +230,7 @@ class HandlersTestCase(CMSTestCase):
         plugin = add_plugin(
             source_placeholder, "PollPlugin", version.content.language, poll=poll
         )
+        plugin.page.get_absolute_url = lambda *args, **kwargs: "/test_page/"  # Fake URL needed for URI
 
         dt = datetime(2016, 6, 6)
         with freeze_time(dt):

--- a/tests/test_locking.py
+++ b/tests/test_locking.py
@@ -394,12 +394,12 @@ class VersionLockEditActionStateTestCase(CMSTestCase):
         author_request.user = self.user_author
         otheruser_request = RequestFactory()
         otheruser_request.user = self.superuser
-        expected_disabled_state = "inactive"
+        expected_disabled_state = ""
 
         actual_disabled_state = self.version_admin._get_edit_link(version, otheruser_request)
 
         self.assertFalse(version.check_edit_redirect.as_bool(self.superuser))
-        self.assertIn(expected_disabled_state, actual_disabled_state)
+        self.assertEqual(expected_disabled_state, actual_disabled_state)
 
 
 @override_settings(DJANGOCMS_VERSIONING_LOCK_VERSIONS=True)

--- a/tests/test_toolbars.py
+++ b/tests/test_toolbars.py
@@ -341,6 +341,13 @@ class VersioningToolbarTestCase(CMSTestCase):
         are published
         """
         published_version = PageVersionFactory(content__language="en", state=PUBLISHED)
+        # Create URL
+        PageUrlFactory(
+            page=published_version.content.page,
+            language=published_version.content.language,
+            path=slugify("test_page"),
+            slug=slugify("test_page"),
+        )
         toolbar = get_toolbar(published_version.content, edit_mode=True)
 
         toolbar.post_template_populate()
@@ -353,6 +360,13 @@ class VersioningToolbarTestCase(CMSTestCase):
         are published
         """
         published_version = PageVersionFactory(content__language="en", state=PUBLISHED)
+        # Create URL
+        PageUrlFactory(
+            page=published_version.content.page,
+            language=published_version.content.language,
+            path=slugify("test_page"),
+            slug=slugify("test_page"),
+        )
         toolbar = get_toolbar(published_version.content, preview_mode=True)
 
         toolbar.post_template_populate()


### PR DESCRIPTION

## Description

Fixes #404 , where the edit action is shown for an unpublished version.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #404 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
