### PR TITLE
fix: Remove workaround for page-specific rendering

### DIFF
--- a/djangocms_versioning/plugin_rendering.py
+++ b/djangocms_versioning/plugin_rendering.py
@@ -42,7 +42,7 @@ class VersionContentRenderer(ContentRenderer):
         prefetch_versioned_related_objects(instance, self.toolbar)
         return super().render_plugin(instance, context, placeholder, editable)
 
-    if cms_version == "4.1.0" or cms_version == "4.1.1":
+    if cms_version in ("4.1.0", "4.1.1"):
         # Only needed for CMS 4.1.0 and 4.1.1 which have fix #7952 not merged
         # With #7952, page-specific rendering works well with versioning.
         def render_obj_placeholder(

--- a/djangocms_versioning/plugin_rendering.py
+++ b/djangocms_versioning/plugin_rendering.py
@@ -1,5 +1,6 @@
 from functools import lru_cache
 
+from cms import __version__ as cms_version
 from cms.plugin_rendering import ContentRenderer, StructureRenderer
 from cms.utils.placeholder import rescan_placeholders_for_obj
 
@@ -41,29 +42,32 @@ class VersionContentRenderer(ContentRenderer):
         prefetch_versioned_related_objects(instance, self.toolbar)
         return super().render_plugin(instance, context, placeholder, editable)
 
-    def render_obj_placeholder(
-        self, slot, context, inherit, nodelist=None, editable=True
-    ):
-        # FIXME This is an ad-hoc solution for page-specific rendering
-        # code, which by default doesn't work well with versioning.
-        # Remove this method once the issue is fixed.
-        from cms.models import Placeholder
+    if cms_version == "4.1.0" or cms_version == "4.1.1":
+        # Only needed for CMS 4.1.0 and 4.1.1 which have fix #7952 not merged
+        # With #7952, page-specific rendering works well with versioning.
+        def render_obj_placeholder(
+            self, slot, context, inherit, nodelist=None, editable=True
+        ):
+            # FIXME This is an ad-hoc solution for page-specific rendering
+            # code, which by default doesn't work well with versioning.
+            # Remove this method once the issue is fixed.
+            from cms.models import Placeholder
 
-        current_obj = self.toolbar.get_object()
+            current_obj = self.toolbar.get_object()
 
-        # Not page, therefore we will use toolbar object as
-        # the current object and render the placeholder
-        rescan_placeholders_for_obj(current_obj)
-        placeholder = Placeholder.objects.get_for_obj(current_obj).get(slot=slot)
-        content = self.render_placeholder(
-            placeholder,
-            context=context,
-            page=current_obj,
-            editable=editable,
-            use_cache=True,
-            nodelist=None,
-        )
-        return content
+            # Not page, therefore we will use toolbar object as
+            # the current object and render the placeholder
+            rescan_placeholders_for_obj(current_obj)
+            placeholder = Placeholder.objects.get_for_obj(current_obj).get(slot=slot)
+            content = self.render_placeholder(
+                placeholder,
+                context=context,
+                page=current_obj,
+                editable=editable,
+                use_cache=True,
+                nodelist=None,
+            )
+            return content
 
 
 class VersionStructureRenderer(StructureRenderer):


### PR DESCRIPTION
## Description

Once, https://github.com/django-cms/django-cms/pull/7924 is merged, the work-around for page-specific rendering is not needed any more. This reactivates the `{% placeholder "my_placeholder" inherit %}` functionality.

Fixes #410.

Requires tests to be added.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* https://github.com/django-cms/django-cms/pull/7924
* #410 

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
