### PR TITLE
fix: Compare versions' back button sometimes returns to invalid URL

### DIFF
--- a/djangocms_versioning/cms_toolbars.py
+++ b/djangocms_versioning/cms_toolbars.py
@@ -212,7 +212,7 @@ class VersioningToolbar(PlaceholderToolbar):
 
                 url += "?" + urlencode({
                     "compare_to": version.pk,
-                    "back": self.request.get_full_path(),
+                    "back": self.toolbar.request_path,
                 })
                 versioning_menu.add_link_item(name, url=url)
                 # Discard changes menu entry (wrt to source)


### PR DESCRIPTION
## Description

"Compare versions" offers a back button. This typically returns to the edit or preview endpoint. 

When editing a plugin and immediately afterwards clicking "Compare versions..." left the back button returning to an internal URL which only updates the toolbar.

This PR ensures that the correct toolbar request path is kept for the back button.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
