### PR TITLE
fix: get_page_content retrieved non page-content objects from the toolbar

### DIFF
--- a/djangocms_versioning/cms_toolbars.py
+++ b/djangocms_versioning/cms_toolbars.py
@@ -295,7 +295,7 @@ class VersioningPageToolbar(PageToolbar):
         super().__init__(*args, **kwargs)
 
     def get_page_content(self, language: Optional[str] = None) -> PageContent:
-        # This method overwrites the method in django CMS core. Not necessary 
+        # This method overwrites the method in django CMS core. Not necessary
         # for django CMS 4.2+
         if not language:
             language = self.current_lang

--- a/djangocms_versioning/cms_toolbars.py
+++ b/djangocms_versioning/cms_toolbars.py
@@ -295,6 +295,8 @@ class VersioningPageToolbar(PageToolbar):
         super().__init__(*args, **kwargs)
 
     def get_page_content(self, language: Optional[str] = None) -> PageContent:
+        # This method overwrites the method in django CMS core. Not necessary 
+        # for django CMS 4.2+
         if not language:
             language = self.current_lang
 
@@ -302,9 +304,9 @@ class VersioningPageToolbar(PageToolbar):
             # Already known - no need to query it again
             return self.page_content
         toolbar_obj = self.toolbar.get_object()
-        if toolbar_obj and toolbar_obj.language == language:
+        if isinstance(toolbar_obj, PageContent) and toolbar_obj.language == language:
             # Already in the toolbar, then use it!
-            return self.toolbar.get_object()
+            return toolbar_obj
         else:
             # Get it from the DB
             return get_latest_admin_viewable_content(self.page, language=language)

--- a/djangocms_versioning/cms_toolbars.py
+++ b/djangocms_versioning/cms_toolbars.py
@@ -300,7 +300,7 @@ class VersioningPageToolbar(PageToolbar):
         if not language:
             language = self.current_lang
 
-        if self.page_content and self.page_content.language == language:
+        if isinstance(self.page_content, PageContent) and self.page_content.language == language:
             # Already known - no need to query it again
             return self.page_content
         toolbar_obj = self.toolbar.get_object()

--- a/djangocms_versioning/test_utils/test_helpers.py
+++ b/djangocms_versioning/test_utils/test_helpers.py
@@ -20,7 +20,7 @@ def get_toolbar(content_obj, user=None, **kwargs):
     request = kwargs.get("request", RequestFactory().get("/"))
     request.user = user
     request.session = kwargs.get("session", {})
-    request.current_page = getattr(content_obj, "page", None)
+    request.current_page = kwargs.get("current_page", getattr(content_obj, "page", None))
     request.toolbar = CMSToolbar(request)
     # Set the toolbar class
     if kwargs.get("toolbar_class", False):

--- a/tests/test_toolbars.py
+++ b/tests/test_toolbars.py
@@ -624,13 +624,11 @@ class VersioningPageToolbarTestCase(CMSTestCase):
 
         version = PollVersionFactory()  # Not a page content model
         page = PageFactory()  # Get a page, e.g. where an apphook is configured
-        request_toolbar = get_toolbar(
-            version.content, edit_mode=True, toolbar_class=VersioningPageToolbar, current_page=page
-        )
+        toolbar = get_toolbar(version.content, edit_mode=True, toolbar_class=VersioningPageToolbar, current_page=page)
 
-        for toolbar in request_toolbar.toolbar.toolbars.values():
-            if hasattr(toolbar, "page_content"):
-                # Did page get detected? Otherwise, page_content never will be detected
-                self.assertIs(toolbar.page, page)
-                self.assertNotIsInstance(toolbar.page_content, version.content.__class__)  # Regression
-                self.assertIsNone(toolbar.page_content)  # Correct result
+        # Did page get detected? Otherwise, page_content never will be detected
+        self.assertIs(toolbar.page, page)
+        # Check regression does not happen
+        self.assertNotIsInstance(toolbar.page_content, version.content.__class__)
+        # Check for correct result
+        self.assertIsNone(toolbar.page_content)

--- a/tests/test_toolbars.py
+++ b/tests/test_toolbars.py
@@ -6,12 +6,14 @@ from django.contrib.auth.models import Permission
 from django.utils.text import slugify
 
 from djangocms_versioning.cms_config import VersioningCMSConfig
+from djangocms_versioning.cms_toolbars import VersioningPageToolbar
 from djangocms_versioning.constants import ARCHIVED, DRAFT, PUBLISHED
 from djangocms_versioning.helpers import version_list_url
 from djangocms_versioning.test_utils.factories import (
     BlogPostVersionFactory,
     FancyPollFactory,
     PageContentWithVersionFactory,
+    PageFactory,
     PageUrlFactory,
     PageVersionFactory,
     PollVersionFactory,
@@ -615,3 +617,20 @@ class VersioningPageToolbarTestCase(CMSTestCase):
 
         language_menu = request.toolbar.get_menu(LANGUAGE_MENU_IDENTIFIER, _("Language"))
         self.assertIsNone(language_menu)
+
+    def test_toolbar_only_catches_page_content_objects(self):
+        """Regression test to ensure that the toolbar only catches PageContent objects and not
+        other toolbar objects."""
+
+        version = PollVersionFactory()  # Not a page content model
+        page = PageFactory()  # Get a page, e.g. where an apphook is configured
+        request_toolbar = get_toolbar(
+            version.content, edit_mode=True, toolbar_class=VersioningPageToolbar, current_page=page
+        )
+
+        for toolbar in request_toolbar.toolbar.toolbars.values():
+            if hasattr(toolbar, "page_content"):
+                # Did page get detected? Otherwise, page_content never will be detected
+                self.assertIs(toolbar.page, page)
+                self.assertNotIsInstance(toolbar.page_content, version.content.__class__)  # Regression
+                self.assertIsNone(toolbar.page_content)  # Correct result


### PR DESCRIPTION
## Description

`cms_toolbars.VersioningPageToolbar.get_page_content` also retrieved non-page content toolbar objects. Fixes #425

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #425 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
