### PR TITLE
feat: add support for Django 5.0 and 5.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
         python setup.py install
 
     - name: Run coverage
-      run: coverage run setup.py test
+      run: coverage run ./test_settings.py
 
     - name: Upload Coverage to Codecov
       uses: codecov/codecov-action@v4
@@ -78,7 +78,7 @@ jobs:
         python setup.py install
 
     - name: Run coverage
-      run: coverage run setup.py test
+      run: coverage run ./test_settings.py
       env:
         DATABASE_URL: postgres://postgres:postgres@127.0.0.1/postgres
 
@@ -122,7 +122,7 @@ jobs:
         python setup.py install
 
     - name: Run coverage
-      run: coverage run setup.py test
+      run: coverage run ./test_settings.py
       env:
         DATABASE_URL: mysql://root@127.0.0.1/djangocms_test
 
@@ -158,7 +158,7 @@ jobs:
         python setup.py install
 
     - name: Run coverage
-      run: coverage run setup.py test
+      run: coverage run ./test_settings.py
 
     - name: Upload Coverage to Codecov
       uses: codecov/codecov-action@v4
@@ -194,7 +194,7 @@ jobs:
         python setup.py install
 
     - name: Run coverage
-      run: coverage run setup.py test
+      run: coverage run ./test_settings.py
 
     - name: Upload Coverage to Codecov
       uses: codecov/codecov-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,15 @@ jobs:
         python-version: [ 3.9, "3.10", "3.11", "3.12" ]  # latest release minus two
         requirements-file: [
             dj32_cms41.txt,
-            dj40_cms41.txt,
-            dj41_cms41.txt,
             dj42_cms41.txt,
+            dj50_cms41.txt,
+            dj51_cms41.txt,
         ]
+        exclude:
+          - requirements-file: dj50_cms41.txt
+            python-version: 3.9
+          - requirements-file: dj51_cms41.txt
+            python-version: 3.9
 
     steps:
     - uses: actions/checkout@v4
@@ -47,9 +52,9 @@ jobs:
         python-version: [ 3.9, "3.10", "3.11", "3.12" ]  # latest release minus two
         requirements-file: [
             dj32_cms41.txt,
-            dj40_cms41.txt,
-            dj41_cms41.txt,
             dj42_cms41.txt,
+            dj50_cms41.txt,
+            dj51_cms41.txt,
         ]
 
     services:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:12
+        image: postgres:13
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,11 @@ jobs:
             dj50_cms41.txt,
             dj51_cms41.txt,
         ]
+        exclude:
+          - requirements-file: dj50_cms41.txt
+            python-version: 3.9
+          - requirements-file: dj51_cms41.txt
+            python-version: 3.9
 
     services:
       postgres:
@@ -98,10 +103,15 @@ jobs:
         python-version: [ 3.9, "3.10", "3.11", "3.12" ]  # latest release minus two
         requirements-file: [
             dj32_cms41.txt,
-            dj40_cms41.txt,
-            dj41_cms41.txt,
             dj42_cms41.txt,
+            dj50_cms41.txt,
+            dj51_cms41.txt,
         ]
+        exclude:
+          - requirements-file: dj50_cms41.txt
+            python-version: 3.9
+          - requirements-file: dj51_cms41.txt
+            python-version: 3.9
 
     services:
       mysql:
@@ -140,7 +150,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.11']
-        requirements-file: ['dj42_cms41.txt']
+        requirements-file: ['dj51_cms41.txt']
         cms-version: [
           'https://github.com/django-cms/django-cms/archive/develop-4.tar.gz'
         ]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,9 +5,20 @@ Changelog
 2.1.0 (2024-07-12)
 ==================
 
+* feat: add support for Django 5.0 and 5.1 (#429) by @fsbraun in https://github.com/django-cms/djangocms-versioning/pull/429
 * feat: Add versioning actions to settings (admin change view) of versioned objects by @fsbraun in https://github.com/django-cms/djangocms-versioning/pull/408
 * fix: Remove workaround for page-specific rendering by @fsbraun in https://github.com/django-cms/djangocms-versioning/pull/411
 * fix: Compare versions' back button sometimes returns to invalid URL by @fsbraun in https://github.com/django-cms/djangocms-versioning/pull/413
+
+
+* feat: Add versioning actions to settings (admin change view) of versioned objects by @fsbraun in https://github.com/django-cms/djangocms-versioning/pull/408
+* feat: Optimize db evaluation by @fsbraun in https://github.com/django-cms/djangocms-versioning/pull/416
+* feat: Prefetch page content version objects for faster page tree by @fsbraun in https://github.com/django-cms/djangocms-versioning/pull/418
+* fix: Remove workaround for page-specific rendering by @fsbraun in https://github.com/django-cms/djangocms-versioning/pull/411
+* fix: Compare versions' back button sometimes returns to invalid URL by @fsbraun in https://github.com/django-cms/djangocms-versioning/pull/413
+* fix: Preparation for changes in django CMS 4.2 by @jrief in https://github.com/django-cms/djangocms-versioning/pull/419
+* fix: Unnecessary complexity in ``current_content`` query set by @fsbraun in https://github.com/django-cms/djangocms-versioning/pull/417
+* fix: get_page_content retrieved non page-content objects from the toolbar by @fsbraun in https://github.com/django-cms/djangocms-versioning/pull/423
 
 
 **Full Changelog**: https://github.com/django-cms/djangocms-versioning/compare/2.0.2...2.1.0

--- a/djangocms_versioning/admin.py
+++ b/djangocms_versioning/admin.py
@@ -61,9 +61,14 @@ from .versionables import _cms_extension
 class VersioningChangeListMixin:
     """Mixin used for ChangeList classes of content models."""
 
-    def get_queryset(self, request):
+    def get_queryset(self, request, exclude_parameters=None):
         """Limit the content model queryset to the latest versions only."""
-        queryset = super().get_queryset(request)
+        if exclude_parameters:
+            # Django 5.0+ (facet support)
+            queryset = super().get_queryset(request, exclude_parameters)
+        else:
+            # Django 4.2 compatible get_queryset
+            queryset = super().get_queryset(request)
         versionable = versionables.for_content(queryset.model)
 
         """Check if there is a method "self.get_<field>_from_request" for each extra grouping field.
@@ -557,7 +562,7 @@ class VersionChangeList(ChangeList):
             if value is not None:
                 yield field, value
 
-    def get_queryset(self, request):
+    def get_queryset(self, request, exclude_parameters=None):
         """Adds support for querying the version model by grouping fields.
 
         Filters by the value of grouping fields (specified in VersionableItem
@@ -567,7 +572,12 @@ class VersionChangeList(ChangeList):
         for specifying filters that work without being shown in the UI
         along with filter choices.
         """
-        queryset = super().get_queryset(request)
+        if exclude_parameters:
+            # Django 5.0+ (facet support)
+            queryset = super().get_queryset(request, exclude_parameters)
+        else:
+            # Django 4.2 compatible get_queryset
+            queryset = super().get_queryset(request)
         content_model = self.model_admin.model._source_model
         versionable = versionables.for_content(content_model)
         filters = dict(self.get_grouping_field_filters(request))

--- a/djangocms_versioning/templates/admin/djangocms_versioning/page/change_form.html
+++ b/djangocms_versioning/templates/admin/djangocms_versioning/page/change_form.html
@@ -19,7 +19,9 @@
                     {% include "admin/djangocms_versioning/versioning_buttons.html" %}
                     <li>
                         {% get_preview_url original as admin_url %}
-                        <a href="{{ admin_url }}" target="_parent">{% trans "Preview" %}</a>
+                        <a href="{{ admin_url }}" onclick="window.parent.CMS.API.Sideframe.close()" target="_parent">
+                            {% trans "Preview" %}
+                        </a>
                     </li>
              {% endblock %}
             </ul>

--- a/djangocms_versioning/test_utils/factories.py
+++ b/djangocms_versioning/test_utils/factories.py
@@ -226,7 +226,7 @@ class PageContentFactory(AbstractContentFactory):
     soft_root = FuzzyChoice([True, False])
     limit_visibility_in_menu = constants.VISIBILITY_USERS
     template = "page.html"
-    xframe_options = FuzzyInteger(0, 4)
+    xframe_options = FuzzyInteger(0, 3)
 
     class Meta:
         model = PageContent

--- a/djangocms_versioning/test_utils/factories.py
+++ b/djangocms_versioning/test_utils/factories.py
@@ -226,7 +226,7 @@ class PageContentFactory(AbstractContentFactory):
     soft_root = FuzzyChoice([True, False])
     limit_visibility_in_menu = constants.VISIBILITY_USERS
     template = "page.html"
-    xframe_options = FuzzyInteger(0, 25)
+    xframe_options = FuzzyInteger(0, 4)
 
     class Meta:
         model = PageContent

--- a/tests/requirements/dj32_cms41.txt
+++ b/tests/requirements/dj32_cms41.txt
@@ -4,5 +4,5 @@ django-cms>=4.1,<4.2
 
 Django>=3.2,<4.0
 django-classy-tags
-django-fsm>=2.6
+django-fsm>=2.6,<3
 django-sekizai

--- a/tests/requirements/dj42_cms41.txt
+++ b/tests/requirements/dj42_cms41.txt
@@ -4,5 +4,5 @@ django-cms>=4.1,<4.2
 
 Django>=4.2,<5
 django-classy-tags
-django-fsm>=2.6
+django-fsm>=2.6,<3
 django-sekizai

--- a/tests/requirements/dj50_cms41.txt
+++ b/tests/requirements/dj50_cms41.txt
@@ -2,7 +2,7 @@
 
 django-cms>=4.1,<4.2
 
-Django>=4.0,<4.1
+Django>=5.0,<5.1
 django-classy-tags
-django-fsm>=2.6
+django-fsm>=2.6,<3
 django-sekizai

--- a/tests/requirements/dj51_cms41.txt
+++ b/tests/requirements/dj51_cms41.txt
@@ -2,7 +2,7 @@
 
 django-cms>=4.1,<4.2
 
-Django>=4.1,<4.2
+Django>=5.1,<5.2
 django-classy-tags
-django-fsm>=2.6
+django-fsm>=2.6,<3
 django-sekizai

--- a/tests/test_cms_config.py
+++ b/tests/test_cms_config.py
@@ -119,7 +119,7 @@ class PageContentVersioningBehaviourTestCase(CMSTestCase):
         form = ChangePageForm(data, instance=self.content)
         form._request = request
         form._site = self.site
-        self.assertEqual(form.is_valid(), True)
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
 
         form.save()
         page = Page.objects.get(pk=self.page.pk)

--- a/tests/test_integration_with_core.py
+++ b/tests/test_integration_with_core.py
@@ -280,9 +280,9 @@ class AdminManagerIntegrationTestCase(CMSTestCase):
         self.page.save()
 
 
-    @skipIf(cms_version < "4.1.3", "Bug only fixed in django CMS 4.1.3")
+    @skipIf(cms_version < "4.1.4", "Bug only fixed in django CMS 4.1.4")
     def test_get_admin_url_for_language(self):
-        """Regression fixed that made unpublished and archived versions invisivle to get_admin_url_for_language
+        """Regression fixed that made unpublished and archived versions invisible to get_admin_url_for_language
         template tag. See: https://github.com/django-cms/django-cms/pull/7967"""
         from django.template import Template
 


### PR DESCRIPTION
## Description

Fixes #428 by adding the optional parameter `exlude_parameters` to the `VersionedChangeList.get_queryset` method. IF provided it will be passed to the `super().get_queryset` method, if not, it will be omitted (to work with Django 4.2).

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #428 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
