### PR TITLE
feat: Autocomplete fields for grouper selection and option for less verbose UI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,7 +155,7 @@ jobs:
           'https://github.com/django-cms/django-cms/archive/develop-4.tar.gz'
         ]
         os: [
-          ubuntu-20.04,
+          ubuntu-latest,
         ]
 
     steps:

--- a/djangocms_versioning/conf.py
+++ b/djangocms_versioning/conf.py
@@ -33,3 +33,9 @@ ON_PUBLISH_REDIRECT = getattr(
     settings, "DJANGOCMS_VERISONING_ON_PUBLISH_REDIRECT", "published"
 )
 #: Allowed values: "versions", "published", "preview"
+
+VERBOSE_UI = getattr(
+    settings, "DJANGOCMS_VERSIONING_VERBOSE_UI", True
+)
+#: If True, the version admin will be offered in the admin index
+#: for each registered versionable model.

--- a/djangocms_versioning/forms.py
+++ b/djangocms_versioning/forms.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from functools import lru_cache
 
 from django import forms

--- a/djangocms_versioning/forms.py
+++ b/djangocms_versioning/forms.py
@@ -5,6 +5,7 @@ from django.contrib.admin.widgets import AutocompleteSelect
 
 from . import versionables
 
+
 class VersionAutocompleteSelect(AutocompleteSelect):
     def optgroups(self, name: str, value: str, attr: dict | None = None):
         default = (None, [], 0)

--- a/djangocms_versioning/templates/djangocms_versioning/admin/grouper_form.html
+++ b/djangocms_versioning/templates/djangocms_versioning/admin/grouper_form.html
@@ -1,4 +1,4 @@
-{% extends "admin/base_site.html" %}
+{% extends "admin/change_form.html" %}
 {% load i18n admin_urls static admin_list %}
 
 {% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} change-list{% endblock %}
@@ -13,6 +13,7 @@
 {% endblock %}
 {% endif %}
 
+{% block extrastyle %}{{ block.super }}{{ form.media }}{% endblock extrastyle %}
 {% block coltype %}flex{% endblock %}
 
 {% block content %}
@@ -33,7 +34,11 @@
     {% endblock %}
     <div class="module" id="changelist">
       <form action="{% url opts|admin_urlname:"changelist" %}">
-        {{ form }}
+          <div class="form-row">
+              <div class="flex-container">
+                  {{ form }}
+              </div>
+          </div>
         <button type="submit">{% translate "Submit" %}</button>
         </form>
       </form>

--- a/djangocms_versioning/templates/djangocms_versioning/admin/grouper_form.html
+++ b/djangocms_versioning/templates/djangocms_versioning/admin/grouper_form.html
@@ -34,11 +34,13 @@
     {% endblock %}
     <div class="module" id="changelist">
       <form action="{% url opts|admin_urlname:"changelist" %}">
+        <fieldset class="module aligned">
           <div class="form-row">
-              <div class="flex-container">
-                  {{ form }}
-              </div>
+            <div class="flex-container">
+              {{ form }}
+            </div>
           </div>
+        </fieldset>
         <button type="submit">{% translate "Submit" %}</button>
         </form>
       </form>

--- a/docs/api/advanced_configuration.rst
+++ b/docs/api/advanced_configuration.rst
@@ -121,7 +121,12 @@ Must be defined if the :ref:`extra_grouping_fields` option has been set. This wi
 grouper_selector_option_label
 ++++++++++++++++++++++++++++++
 
-If the version table link is specified without a grouper param, a form with a dropdown of grouper objects will display. This setting defines how the labels of those groupers will display on the dropdown.
+If the version table link is specified without a grouper param, a form with a dropdown of grouper objects will display. By default, if the grouper object is registered with the
+admin and has a ``search_fields`` attribute, the dropdown will be an autocomplete
+field which will display the object's ``__str__`` method. This is the recommended
+method.
+
+For models not registerd with the admin, or without search fields, this setting defines how the labels of those groupers will display on the dropdown (regular select field).
 
 
 .. code-block:: python

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -89,3 +89,13 @@ Settings for djangocms Versioning
     * ``"preview"``: The user will be redirected to the content object's
       preview endpoint.
 
+.. py:attribute:: DJANGOCMS_VERISONING_VERBOSE_UI
+
+    Defaults to ``True``
+
+    For many users it is sufficient to interact with djangocms-versioning
+    through a less verbose UI. If set to ``False``, djangocms-versioning will
+    not display the creation date in the "manage versions" view. Also, it will
+    remove its entries in the django admin overview page (index).
+    "manage versions" remains accessible trough the version menu in the CMS
+    toolbar.


### PR DESCRIPTION
## Description

1. This PR adds **autocomplete** fields and some minimal styling to the grouper form when accessing the version change list:
   <img width="656" alt="image" src="https://github.com/user-attachments/assets/0d8c372e-0dd3-48ba-8470-42742348874c">
   Before this was a classical select drop-down which quickly gets difficult to handle with a growing number of pages or other grouper objects.

2. Option for less verbose UI: Setting `DJANGOCMS_VERSIONING_VERBOSE_UI ? False` will remove the version change lists from the admin index view (to not clutter it). Version management is still accessible through the versioned models' admins. Also, it will make the version change list less wide by removing the created by date for easier access to the action buttons:
   <img width="865" alt="image" src="https://github.com/user-attachments/assets/4fc45778-b9b2-4752-976c-7940c6a9659a">

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* https://github.com/django-cms/django-cms/pull/8067 required for this PR to work
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
