### PR TITLE
fix uniweb-issue-1353: attempt to remove missing item from list

### DIFF
--- a/djangocms_versioning/admin.py
+++ b/djangocms_versioning/admin.py
@@ -916,7 +916,7 @@ class VersionAdmin(ChangeListActionsMixin, admin.ModelAdmin, metaclass=MediaDefi
             f"admin:{self.model._meta.app_label}_{self.model._meta.model_name}_compare",
             args=(queryset[0].pk,),
         )
-        url += "?compare_to=%d" % queryset[1].pk
+        url += f"?compare_to={queryset[1].pk}"
 
         return redirect(url)
 

--- a/djangocms_versioning/cms_config.py
+++ b/djangocms_versioning/cms_config.py
@@ -279,7 +279,7 @@ class VersioningCMSPageAdminMixin(VersioningAdminMixin):
                 if form.fieldsets:
                     fields = flatten_fieldsets(form.fieldsets)
                 fields = list(fields)
-                for f_name in ["slug", "overwrite_url"]:
+                for f_name in {"slug", "overwrite_url"}.intersection(fields):
                     fields.remove(f_name)
         return fields
 

--- a/djangocms_versioning/test_utils/factories.py
+++ b/djangocms_versioning/test_utils/factories.py
@@ -104,7 +104,7 @@ class PollContentWithVersionFactory(PollContentFactory):
 class AnswerFactory(factory.django.DjangoModelFactory):
     poll_content = factory.SubFactory(PollContentFactory)
     text = factory.LazyAttributeSequence(
-        lambda o, n: "Poll %s - Answer %d" % (o.poll_content.poll.name, n)
+        lambda o, n: f"Poll {o.poll_content.poll.name} - Answer {n}"
     )
 
     class Meta:

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -2156,7 +2156,7 @@ class CompareViewTestCase(CMSTestCase):
         url = self.get_admin_url(
             self.versionable.version_model_proxy, "compare", versions[0].pk
         )
-        url += "?compare_to=%d" % versions[1].pk
+        url += f"?compare_to={versions[1].pk}"
         user = self.get_staff_user_with_no_permissions()
 
         with self.login_user_context(user):


### PR DESCRIPTION
## Description

Fix #430: sometimes fields are missing in list

## Related resources

* #430

## Checklist

* [x] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Bug Fixes:
- Fix an issue where sometimes "slug" and "overwrite_url" fields were missing in the list of read-only fields, resulting in an error.