### PR TITLE
feat: Pre-populate `version.content` cache when getting version object

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,7 +149,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.11']
+        python-version: ['3.12']
         requirements-file: ['dj51_cms41.txt']
         cms-version: [
           'https://github.com/django-cms/django-cms/archive/develop-4.tar.gz'
@@ -183,7 +183,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.11" ]
+        python-version: [ "3.12" ]
         cms-version: [
           'https://github.com/django-cms/django-cms/archive/develop-4.tar.gz'
         ]

--- a/djangocms_versioning/cms_config.py
+++ b/djangocms_versioning/cms_config.py
@@ -1,5 +1,6 @@
 import collections
 
+from cms import __version__ as cms_version
 from cms.app_base import CMSAppConfig, CMSAppExtension
 from cms.extensions.models import BaseExtension
 from cms.models import PageContent, Placeholder
@@ -22,6 +23,7 @@ from django.http import (
 from django.utils.encoding import force_str
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
+from packaging.version import Version as PackageVersion
 
 from . import indicators
 from .admin import VersioningAdminMixin
@@ -393,6 +395,7 @@ class VersioningCMSConfig(CMSAppConfig):
             content_admin_mixin=VersioningCMSPageAdminMixin,
         )
     ]
-    cms_toolbar_mixin = CMSToolbarVersioningMixin
+    if PackageVersion(cms_version) < PackageVersion("4.2"):
+        cms_toolbar_mixin = CMSToolbarVersioningMixin
     PageContent.add_to_class("is_editable", is_editable)
     PageContent.add_to_class("content_indicator", indicators.content_indicator)

--- a/djangocms_versioning/cms_toolbars.py
+++ b/djangocms_versioning/cms_toolbars.py
@@ -242,7 +242,7 @@ class VersioningToolbar(PlaceholderToolbar):
 
         return PageContent._original_manager.filter(
             page=self.page, language=language, versions__state=PUBLISHED
-        ).first()
+        ).select_related("page").first()
 
     def _add_view_published_button(self):
         """Helper method to add a publish button to the toolbar

--- a/djangocms_versioning/cms_toolbars.py
+++ b/djangocms_versioning/cms_toolbars.py
@@ -5,8 +5,8 @@ from typing import Optional
 from cms import __version__ as cms_version
 from cms.cms_toolbars import (
     ADD_PAGE_LANGUAGE_BREAK,
-    BasicToolbar,
     LANGUAGE_MENU_IDENTIFIER,
+    BasicToolbar,
     PageToolbar,
     PlaceholderToolbar,
 )
@@ -445,7 +445,7 @@ class VersioningBasicToolbar(BasicToolbar):
             return super().add_language_menu()
 
         language_menu = self.toolbar.get_or_create_menu(
-            LANGUAGE_MENU_IDENTIFIER, _('Language'), position=-1
+            LANGUAGE_MENU_IDENTIFIER, _("Language"), position=-1
         )
         for code, name in get_language_tuple(self.current_site.pk):
             # Get the page content, it could be draft too!

--- a/djangocms_versioning/cms_toolbars.py
+++ b/djangocms_versioning/cms_toolbars.py
@@ -442,7 +442,8 @@ class VersioningBasicToolbar(BasicToolbar):
         """
         if not settings.USE_I18N or not self.request.current_page:
             # Only add if no page is shown
-            return super().add_language_menu()
+            super().add_language_menu()
+            return
 
         language_menu = self.toolbar.get_or_create_menu(
             LANGUAGE_MENU_IDENTIFIER, _("Language"), position=-1

--- a/djangocms_versioning/datastructures.py
+++ b/djangocms_versioning/datastructures.py
@@ -176,8 +176,7 @@ class VersionableItem(BaseVersionableItem):
 
 
 class PolymorphicVersionableItem(VersionableItem):
-    """VersionableItem for use by base polymorphic class
-    (for example filer.File).
+    """VersionableItem for use by base polymorphic class (for example filer.File).
     """
 
     def _get_content_types(self):

--- a/djangocms_versioning/models.py
+++ b/djangocms_versioning/models.py
@@ -245,11 +245,11 @@ class Version(models.Model):
         of its correct proxy model"""
 
         cache = self._state.fields_cache
-        del self._state.fields_cache  # Remove cache before creating deep copying
+        del self._state.fields_cache  # Remove cache before creating deep copy
         new_obj = copy.deepcopy(self)
-        new_obj.__class__ = self.versionable.version_model_proxy
         new_obj._state.fields_cache = cache  # Recover caches
         self._state.fields_cache = cache  # Recover caches
+        new_obj.__class__ = self.versionable.version_model_proxy
         return new_obj
 
     @property

--- a/djangocms_versioning/models.py
+++ b/djangocms_versioning/models.py
@@ -51,6 +51,7 @@ class VersionQuerySet(models.QuerySet):
         version = self.get(
             object_id=content_object.pk, content_type__in=versionable.content_types
         )
+        version._state.fields_cache['content'] = content_object
         content_object._version_cache = version
         return version
 
@@ -243,8 +244,12 @@ class Version(models.Model):
         """Returns a copy of current Version object, but as an instance
         of its correct proxy model"""
 
+        cache = self._state.fields_cache
+        del self._state.fields_cache  # Remove cache before creating deep copying
         new_obj = copy.deepcopy(self)
         new_obj.__class__ = self.versionable.version_model_proxy
+        new_obj._state.fields_cache = cache  # Recover caches
+        self._state.fields_cache = cache  # Recover caches
         return new_obj
 
     @property

--- a/djangocms_versioning/plugin_rendering.py
+++ b/djangocms_versioning/plugin_rendering.py
@@ -1,4 +1,3 @@
-from functools import lru_cache
 
 from cms import __version__ as cms_version
 from cms.plugin_rendering import ContentRenderer, StructureRenderer

--- a/djangocms_versioning/plugin_rendering.py
+++ b/djangocms_versioning/plugin_rendering.py
@@ -59,6 +59,7 @@ class VersionContentRenderer(ContentRenderer):
             # the current object and render the placeholder
             rescan_placeholders_for_obj(current_obj)
             placeholder = Placeholder.objects.get_for_obj(current_obj).get(slot=slot)
+            placeholder._state.fields_cache["source"] = current_obj  # Cache reverse relation
             content = self.render_placeholder(
                 placeholder,
                 context=context,

--- a/djangocms_versioning/plugin_rendering.py
+++ b/djangocms_versioning/plugin_rendering.py
@@ -50,12 +50,15 @@ class VersionContentRenderer(ContentRenderer):
         ):
             # FIXME This is an ad-hoc solution for page-specific rendering
             # code, which by default doesn't work well with versioning.
+            # Remove this method once the issue is fixed.
+            from cms.models import Placeholder
 
             current_obj = self.toolbar.get_object()
 
             # Not page, therefore we will use toolbar object as
             # the current object and render the placeholder
-            placeholder = rescan_placeholders_for_obj(current_obj).get(slot)
+            rescan_placeholders_for_obj(current_obj)
+            placeholder = Placeholder.objects.get_for_obj(current_obj).get(slot=slot)
             content = self.render_placeholder(
                 placeholder,
                 context=context,

--- a/djangocms_versioning/plugin_rendering.py
+++ b/djangocms_versioning/plugin_rendering.py
@@ -59,7 +59,6 @@ class VersionContentRenderer(ContentRenderer):
             # the current object and render the placeholder
             rescan_placeholders_for_obj(current_obj)
             placeholder = Placeholder.objects.get_for_obj(current_obj).get(slot=slot)
-            placeholder._state.fields_cache["source"] = current_obj  # Cache reverse relation
             content = self.render_placeholder(
                 placeholder,
                 context=context,

--- a/tests/test_integration_with_core.py
+++ b/tests/test_integration_with_core.py
@@ -7,7 +7,7 @@ from cms.utils.urlutils import admin_reverse
 from django.template import Context
 
 from djangocms_versioning import constants
-from djangocms_versioning.plugin_rendering import VersionContentRenderer, CMSToolbarVersioningMixin
+from djangocms_versioning.plugin_rendering import CMSToolbarVersioningMixin, VersionContentRenderer
 from djangocms_versioning.test_utils.factories import (
     PageFactory,
     PageVersionFactory,

--- a/tests/test_integration_with_core.py
+++ b/tests/test_integration_with_core.py
@@ -5,6 +5,7 @@ from cms.test_utils.testcases import CMSTestCase
 from cms.toolbar.toolbar import CMSToolbar
 from cms.utils.urlutils import admin_reverse
 from django.template import Context
+from packaging.version import Version as PackageVersion
 
 from djangocms_versioning import constants
 from djangocms_versioning.plugin_rendering import CMSToolbarVersioningMixin, VersionContentRenderer
@@ -18,6 +19,7 @@ from djangocms_versioning.test_utils.factories import (
 )
 
 
+@skipIf(PackageVersion(cms_version) >= PackageVersion("4.2"), "Toolbar integration not necessary for django CMS 4.2+")
 class CMSToolbarTestCase(CMSTestCase):
     def test_content_renderer(self):
         """Test that cms.toolbar.toolbar.CMSToolbar.content_renderer
@@ -39,7 +41,6 @@ class CMSToolbarTestCase(CMSTestCase):
 
 
 class PageContentAdminTestCase(CMSTestCase):
-
     def test_get_admin_model_object(self):
         """
         PageContent normally won't be able to fetch objects in draft. Test if the RequestToolbarForm
@@ -71,7 +72,6 @@ class PageContentAdminTestCase(CMSTestCase):
 
 
 class PageAdminCopyLanguageTestCase(CMSTestCase):
-
     def setUp(self):
         self.user = self.get_superuser()
         page = PageFactory()
@@ -281,7 +281,8 @@ class AdminManagerIntegrationTestCase(CMSTestCase):
         self.page.save()
 
 
-    @skipIf(cms_version < "4.1.4", "Bug only fixed in django CMS 4.1.4")
+    @skipIf(PackageVersion(cms_version) < PackageVersion("4.1.4"),
+            "Bug only fixed in django CMS 4.1.4")
     def test_get_admin_url_for_language(self):
         """Regression fixed that made unpublished and archived versions invisible to get_admin_url_for_language
         template tag. See: https://github.com/django-cms/django-cms/pull/7967"""

--- a/tests/test_integration_with_core.py
+++ b/tests/test_integration_with_core.py
@@ -7,7 +7,7 @@ from cms.utils.urlutils import admin_reverse
 from django.template import Context
 
 from djangocms_versioning import constants
-from djangocms_versioning.plugin_rendering import VersionContentRenderer
+from djangocms_versioning.plugin_rendering import VersionContentRenderer, CMSToolbarVersioningMixin
 from djangocms_versioning.test_utils.factories import (
     PageFactory,
     PageVersionFactory,
@@ -24,6 +24,7 @@ class CMSToolbarTestCase(CMSTestCase):
         is replaced with a property returning VersionContentRenderer
         """
         request = self.get_request("/")
+        self.assertIn(CMSToolbarVersioningMixin, CMSToolbar.__mro__)
         self.assertEqual(
             CMSToolbar(request).content_renderer.__class__, VersionContentRenderer
         )

--- a/tests/test_toolbars.py
+++ b/tests/test_toolbars.py
@@ -8,6 +8,7 @@ from cms.test_utils.testcases import CMSTestCase
 from cms.toolbar.utils import get_object_edit_url, get_object_preview_url
 from cms.utils.urlutils import admin_reverse
 from django.contrib.auth.models import Permission
+from django.test import override_settings
 from django.utils.text import slugify
 from packaging.version import Version
 
@@ -669,6 +670,7 @@ class VersioningPageToolbarTestCase(CMSTestCase):
         self.assertEqual(de_item.url, de_preview_url)
         self.assertEqual(it_item.url, it_preview_url)
 
+    @override_settings(USE_I18N=False)
     def test_page_toolbar_wo_language_menu(self):
         from django.utils.translation import gettext as _
 
@@ -681,13 +683,13 @@ class VersioningPageToolbarTestCase(CMSTestCase):
             user=self.get_superuser(),
         )
         # Remove language menu from request's toolbar
-        del request.toolbar.menus[LANGUAGE_MENU_IDENTIFIER]
+        self.assertNotIn(LANGUAGE_MENU_IDENTIFIER, request.toolbar.menus)
 
-        # find VersioningPageToolbar
+        # find VersioningBasicToolbar
         for cls, toolbar in request.toolbar.toolbars.items():
-            if cls == "djangocms_versioning.cms_toolbars.VersioningPageToolbar":
+            if cls == "djangocms_versioning.cms_toolbars.VersioningBasicToolbar":
                 # and call override_language_menu
-                toolbar.override_language_menu()
+                toolbar.add_language_menu()
                 break
 
         language_menu = request.toolbar.get_menu(LANGUAGE_MENU_IDENTIFIER, _("Language"))


### PR DESCRIPTION
## Description

The checks framework triggers database hits when accessing a `version.content` object. This PR adds the content object to the version's field cache to avoid these unnecessary database hits.

The failing test against django-cms@develop-4 fails due to an import order issue for the core's `cms.toolbar.toolbar.CMSToolbar`. This prevents the core to use versioning's prefetching and is fixed by https://github.com/django-cms/django-cms/pull/8120

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* https://github.com/django-cms/django-cms/pull/8120
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Enhancements:
- Improve performance by reducing database hits when accessing version content.