### PR TITLE
ci: update ruff configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.ruff]
-exclude = [
+extend-exclude = [
   ".eggs",
   ".git",
   ".mypy_cache",
@@ -13,7 +13,6 @@ exclude = [
 line-length = 120
 
 [tool.ruff.lint]
-# https://beta.ruff.rs/docs/configuration/
 select = [
   "E",  # pycodestyle errors
   "W",  # pycodestyle warnings
@@ -21,17 +20,17 @@ select = [
   "I",  # isort
   "C",  # flake8-comprehensions
   "B",  # flake8-bugbear
-  "Q", # flake8-quotes
+  "Q",  # flake8-quotes
   "PLE", # pylint error
   "PLR", # pylint refactor
   "PLW", # pylint warning
-  "UP", # pyupgrade
+  "UP",  # pyupgrade
 ]
 
-ignore = [
+extend-ignore = [
   "B006",  # Do not use mutable data structures for argument defaults
   "B011",  # tests use assert False
-  "B019",  # Use of `functools.lru_cache` or `functools.cache` on methods can lead to memory leaks
+  "B019",  # Use of `functools.lru_cache` on methods can lead to memory leaks
   "B905",  # `zip()` without an explicit `strict=` parameter
   "C901",  # too complex functions
   "E402",  # module level import not at top of file
@@ -43,6 +42,10 @@ ignore = [
   "PLR2004",  # Magic value used in comparison, consider replacing with a constant variable
   "UP007",  # Use `X | Y` for type annotations
 ]
+
+# TODO: fix these checks separately
+# "E501" - Line too long
+# "F401" - Unused imports
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = [


### PR DESCRIPTION
## Description

Update ruff configuration to be in sync with `django-cms`. The line length that was already defined here is 120. Let me know if we need to update that to 119. Closes #376 

## Summary by Sourcery

CI:
- Update Ruff configuration to extend existing excludes and ignores instead of overwriting them, and add a TODO to fix remaining issues separately