### PR TITLE
fix: Test compatibility with django CMS 5

### DIFF
--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -93,7 +93,7 @@ class HandlersTestCase(CMSTestCase):
 
             with self.login_user_context(self.get_superuser()):
                 response = self.client.post(endpoint, data)
-                self.assertEqual(response.status_code, 302)
+                self.assertIn(response.status_code, (200, 302))  # 302 for django CMS < 5
 
         version = Version.objects.get(pk=version.pk)
         self.assertEqual(version.modified, dt)

--- a/tests/test_integration_with_core.py
+++ b/tests/test_integration_with_core.py
@@ -277,7 +277,10 @@ class AdminManagerIntegrationTestCase(CMSTestCase):
             content__language="fr",
             state=constants.ARCHIVED,
         )
-        self.page.languages = "en,fr"
+        try:
+            self.page.languages = "en,fr"
+        except AttributeError:
+            pass
         self.page.save()
 
 

--- a/tests/test_integration_with_core.py
+++ b/tests/test_integration_with_core.py
@@ -280,6 +280,7 @@ class AdminManagerIntegrationTestCase(CMSTestCase):
         try:
             self.page.languages = "en,fr"
         except AttributeError:
+            # The property does not have a setter in django CMS 5+
             pass
         self.page.save()
 


### PR DESCRIPTION
## Description

This PR fixes tests to run with django CMS 5.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Make tests compatible with django CMS 5.

Tests:
- Allow status code 200 in addition to 302 in test_delete_plugin to support django CMS < 5.
- Handle AttributeError when setting page languages to support django CMS < 5.