### PR TITLE
fix: For headless mode, django CMS 5.0 adds preview buttons to all views. Do not add again.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -183,7 +183,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.11" ]
+        python-version: [ "3.12" ]
         cms-version: [
           'https://github.com/django-cms/django-cms/archive/develop-4.tar.gz'
         ]

--- a/djangocms_versioning/cms_toolbars.py
+++ b/djangocms_versioning/cms_toolbars.py
@@ -37,6 +37,7 @@ from djangocms_versioning.models import Version
 
 VERSIONING_MENU_IDENTIFIER = "version"
 CMS_SUPPORTS_DELETING_TRANSLATIONS = version.Version(cms_version) > version.Version("4.1.4")
+CMS_ADDS_PREVIEW_BUTTON = version.Version(cms_version) >= version.Version("4.2")
 
 
 class VersioningToolbar(PlaceholderToolbar):
@@ -270,7 +271,7 @@ class VersioningToolbar(PlaceholderToolbar):
     def _add_preview_button(self):
         """Helper method to add a preview button to the toolbar when not in preview mode"""
         # Check if object is registered with versioning otherwise don't add
-        if not self._is_versioned():
+        if not self._is_versioned() or CMS_ADDS_PREVIEW_BUTTON:
             return
 
         if not self.toolbar.preview_mode_active and not self.toolbar.edit_mode_active:


### PR DESCRIPTION
## Description

fixes #454 


## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #454 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
