### PR TITLE
fix: Remove unnecessary `_original_manager` usage from toolbar

### DIFF
--- a/djangocms_versioning/cms_toolbars.py
+++ b/djangocms_versioning/cms_toolbars.py
@@ -29,7 +29,7 @@ from django.utils.translation import gettext_lazy as _
 from packaging import version
 
 from djangocms_versioning.conf import ALLOW_DELETING_VERSIONS, LOCK_VERSIONS
-from djangocms_versioning.constants import DRAFT, PUBLISHED
+from djangocms_versioning.constants import DRAFT
 from djangocms_versioning.helpers import (
     get_latest_admin_viewable_content,
     version_list_url,
@@ -242,8 +242,8 @@ class VersioningToolbar(PlaceholderToolbar):
         if not isinstance(self.toolbar.obj, PageContent) or not self.page:
             return
 
-        return PageContent._original_manager.filter(
-            page=self.page, language=language, versions__state=PUBLISHED
+        return PageContent.objects.filter(
+            page=self.page, language=language
         ).select_related("page").first()
 
     def _add_view_published_button(self):


### PR DESCRIPTION
## Description

The toolbar accesses `_original_manager` which is the style of djangocms-versioning<2. For consistency and unnecessary code repetition, the `objects` manager should be used for getting published content.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Use the default PageContent manager instead of the outdated `_original_manager` when fetching published content in the CMS toolbar

Enhancements:
- Replace `PageContent._original_manager.filter` with `PageContent.objects.filter` in `_get_published_page_version`
- Add `select_related("page")` to optimize the published content query