### PR TITLE
Fix multi site

### DIFF
--- a/djangocms_versioning/admin.py
+++ b/djangocms_versioning/admin.py
@@ -1101,9 +1101,14 @@ class VersionAdmin(ChangeListActionsMixin, admin.ModelAdmin, metaclass=MediaDefi
         self.message_user(request, _("Version published"))
 
         # Redirect to published?
-        if conf.ON_PUBLISH_REDIRECT == "published":
-            if hasattr(version.content, "get_absolute_url"):
-                requested_redirect = requested_redirect or version.content.get_absolute_url()
+        if not requested_redirect and conf.ON_PUBLISH_REDIRECT == "published":
+            if hasattr(version.content, "get_full_url"):
+                full_url = version.content.get_full_url()
+                if full_url:
+                    # Can't resolve full_url, redirect directly to it
+                    return redirect(full_url)
+            elif hasattr(version.content, "get_absolute_url"):
+                requested_redirect = version.content.get_absolute_url()
 
         return self._internal_redirect(requested_redirect, redirect_url)
 

--- a/djangocms_versioning/cms_toolbars.py
+++ b/djangocms_versioning/cms_toolbars.py
@@ -258,7 +258,9 @@ class VersioningToolbar(PlaceholderToolbar):
         if not published_version:
             return
 
-        url = published_version.get_absolute_url() if hasattr(published_version, "get_absolute_url") else None
+        url = published_version.get_full_url() if hasattr(published_version, "get_full_url") else None
+        if not url and hasattr(published_version, "get_absolute_url"):
+            url = published_version.get_absolute_url()
         if url and (self.toolbar.edit_mode_active or self.toolbar.preview_mode_active):
             item = ButtonList(side=self.toolbar.RIGHT)
             item.add_button(

--- a/djangocms_versioning/templates/admin/djangocms_versioning/page/change_form.html
+++ b/djangocms_versioning/templates/admin/djangocms_versioning/page/change_form.html
@@ -34,7 +34,7 @@
 
 
 
-<form {% if has_file_field %}enctype="multipart/form-data" {% endif %}action="?language={{ language }}{% if request.GET.parent_page %}&amp;parent_page={{ request.GET.parent_page }}{% endif %}{# parameter `parent_node` only for django CMS 4.1 support #}{% if request.GET.parent_node %}&amp;parent_node={{ request.GET.parent_node }}{% endif %}{%if request.GET.source %}&amp;source={{ request.GET.source }}{% endif %}" method="post" id="{{ opts.model_name }}_form">
+<form {% if has_file_field %}enctype="multipart/form-data" {% endif %}action="?language={{ language }}{% if request.GET.site %}&amp;site={{ request.GET.site }}{% endif %}{% if request.GET.parent_page %}&amp;parent_page={{ request.GET.parent_page }}{% endif %}{# parameter `parent_node` only for django CMS 4.1 support #}{% if request.GET.parent_node %}&amp;parent_node={{ request.GET.parent_node }}{% endif %}{%if request.GET.source %}&amp;source={{ request.GET.source }}{% endif %}" method="post" id="{{ opts.model_name }}_form">
 {% csrf_token %}
 {% block form_top %}{% endblock %}
 


### PR DESCRIPTION
## Description

This builds on [django-cms#8303](https://github.com/django-cms/django-cms/pull/8303) and copies the changes to page admin change form template.
The URL for published content can now be behind `get_full_url` in order to access a separate domain when the versioned object is associated with a different site.

## Related resources

- https://github.com/django-cms/django-cms/pull/8303

## Checklist

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
