### PR TITLE
fix: Invalid permission checking in ExtendedVersionAdminMixin

### DIFF
--- a/djangocms_versioning/admin.py
+++ b/djangocms_versioning/admin.py
@@ -17,6 +17,7 @@ from django.contrib.admin.actions import delete_selected
 from django.contrib.admin.options import IncorrectLookupParameters
 from django.contrib.admin.utils import unquote
 from django.contrib.admin.views.main import ChangeList
+from django.contrib.auth import get_permission_codename
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ImproperlyConfigured, ObjectDoesNotExist, PermissionDenied
 from django.db import models
@@ -525,7 +526,7 @@ class ExtendedVersionAdminMixin(
             # Don't display the link if it can't be edited
             return ""
 
-        if not request.user.has_perm(f"{obj._meta.app_label}.{obj._meta.model_name}"):
+        if not request.user.has_perm(f"{obj._meta.app_label}.{get_permission_codename('change', obj._meta)}"):
             # Grey out if user has not sufficient right to edit
             disabled = True
 


### PR DESCRIPTION
## Description

In `ExtendedVersionAdminMixin._get_edit_link()`, the permission checking is invalid :


In the following line :
```
if not request.user.has_perm(f"{obj._meta.app_label}.{obj._meta.model_name}")
```

The permission being checked is for example : `djangocms_snippet.snippet` instead of `djangocms_snippet.change_snippet`


## Related resources

...

## Checklist

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Bug Fixes:
- Correct edit-link permission checks in ExtendedVersionAdminMixin to require the appropriate change permission instead of a generic model permission.