### PR TITLE
chore: upgrade GitHub Actions versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8
 
     - name: Install ruff
       run: uv tool install ruff

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v8
+      uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57
 
     - name: Install ruff
       run: uv tool install ruff

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,10 +52,6 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt install gettext gcc -y
-        sudo apt install gettext gcc -y
-        sudo apt install gettext gcc -y
-        python -m pip install --upgrade pip uv
-        python -m pip install --upgrade pip uv
         python -m pip install --upgrade pip uv
         uv pip install --system -r tests/requirements/${{ matrix.requirements-file }}
         uv pip install --system -e .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8
     - name: Install dependencies
       run: |
         sudo apt install gettext gcc -y
@@ -121,7 +121,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8
     - name: Install dependencies
       run: |
         uv pip install --system -r tests/requirements/${{ matrix.requirements-file }}
@@ -188,7 +188,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8
     - name: Install dependencies
       run: |
         uv pip install --system -r tests/requirements/${{ matrix.requirements-file }}
@@ -223,7 +223,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8
     - name: Install dependencies
       run: |
         uv pip install --system -r tests/requirements/${{ matrix.requirements-file }}
@@ -258,7 +258,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8
     - name: Install dependencies
       run: |
         uv pip install --system -r tests/requirements/${{ matrix.requirements-file }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install uv
-      uses: astral-sh/setup-uv@v8
+      uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57
     - name: Install dependencies
       run: |
         sudo apt install gettext gcc -y
@@ -117,7 +117,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install uv
-      uses: astral-sh/setup-uv@v8
+      uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57
     - name: Install dependencies
       run: |
         uv pip install --system -r tests/requirements/${{ matrix.requirements-file }}
@@ -184,7 +184,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install uv
-      uses: astral-sh/setup-uv@v8
+      uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57
     - name: Install dependencies
       run: |
         uv pip install --system -r tests/requirements/${{ matrix.requirements-file }}
@@ -219,7 +219,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install uv
-      uses: astral-sh/setup-uv@v8
+      uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57
     - name: Install dependencies
       run: |
         uv pip install --system -r tests/requirements/${{ matrix.requirements-file }}
@@ -254,7 +254,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install uv
-      uses: astral-sh/setup-uv@v8
+      uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57
     - name: Install dependencies
       run: |
         uv pip install --system -r tests/requirements/${{ matrix.requirements-file }}


### PR DESCRIPTION
## Summary
- upgrade outdated GitHub Actions versions listed in the repository audit
- align workflow action references with their current supported versions

## Testing
- not run (workflow-only change)

## Summary by Sourcery

CI:
- Bump astral-sh/setup-uv action from v7 to v8 across test and lint GitHub workflows.