### PR TITLE
Add Versioning Buttons to Grouper Admin.

### DIFF
--- a/djangocms_versioning/admin.py
+++ b/djangocms_versioning/admin.py
@@ -309,6 +309,21 @@ class ExtendedGrouperVersionAdminMixin(ExtendedListDisplayMixin):
 
     """
 
+    change_form_template = "djangocms_versioning/admin/grouper/change_form.html"
+
+    def render_change_form(self, request, context, add=False, change=False, form_url="", obj=None):
+        """Expose the current content object to the change form so the
+        versioning object-tools buttons (Publish / New Draft / Revert /
+        Versions) can be rendered for grouper admins.
+        """
+        if "versioning_fallback_change_form_template" not in context:
+            context["versioning_fallback_change_form_template"] = super().change_form_template
+        if obj is not None:
+            context["versioning_content_obj"] = self.get_content_obj(obj)
+        return super().render_change_form(
+            request, context, add=add, change=change, form_url=form_url, obj=obj
+        )
+
     def get_queryset(self, request: HttpRequest) -> models.QuerySet:
         """Annotates the username of the ``created_by`` field, the ``modified`` field (date time),
         and the ``state`` field of the version object to the grouper queryset."""

--- a/djangocms_versioning/admin.py
+++ b/djangocms_versioning/admin.py
@@ -1280,8 +1280,14 @@ class VersionAdmin(ChangeListActionsMixin, admin.ModelAdmin, metaclass=MediaDefi
             self.message_user(request, force_str(e), messages.ERROR)
             return redirect(version_list_url(version.content))
 
-        # Redirect
-        return redirect(get_editable_url(target.content, request.GET.get("force_admin"), request.GET))
+        # Honour ?next= when it resolves to a known admin URL; otherwise
+        # fall back to the default editable URL. Matches the convention
+        # used by publish/revert/archive/discard/unpublish views.
+        requested_redirect = request.GET.get("next")
+        fallback = get_editable_url(
+            target.content, request.GET.get("force_admin"), request.GET
+        )
+        return self._internal_redirect(requested_redirect, fallback)
 
     def revert_view(self, request, object_id):
         """Reverts to the specified version i.e. creates a draft from it."""

--- a/djangocms_versioning/templates/admin/djangocms_versioning/grouper_versioning_buttons.html
+++ b/djangocms_versioning/templates/admin/djangocms_versioning/grouper_versioning_buttons.html
@@ -1,0 +1,31 @@
+{% load djangocms_versioning i18n %}
+{% if versioning_content_obj %}
+    {% with url=versioning_content_obj|url_publish_version:request.user %}
+        {% if url %}
+            <li>
+                <a class="accent cms-form-post-method" href="{{ url }}?next={{ request.path }}">{% trans "Publish" %}</a>
+            </li>
+        {% endif %}
+    {% endwith %}
+    {% with url=versioning_content_obj|url_new_draft:request.user %}
+        {% if url %}
+            <li>
+                <a class="accent cms-form-post-method" href="{{ url }}?next={{ request.path }}">{% trans "New Draft" %}</a>
+            </li>
+        {% endif %}
+    {% endwith %}
+    {% with url=versioning_content_obj|url_revert_version:request.user %}
+        {% if url %}
+            <li>
+                <a href="{{ url }}?next={{ request.path }}">{% trans "Revert" %}</a>
+            </li>
+        {% endif %}
+    {% endwith %}
+    {% with url=versioning_content_obj|url_version_list %}
+        {% if url %}
+            <li>
+                <a href="{{ url }}">{% trans "Versions" %}</a>
+            </li>
+        {% endif %}
+    {% endwith %}
+{% endif %}

--- a/djangocms_versioning/templates/djangocms_versioning/admin/grouper/change_form.html
+++ b/djangocms_versioning/templates/djangocms_versioning/admin/grouper/change_form.html
@@ -1,0 +1,17 @@
+{% extends versioning_fallback_change_form_template|default:"admin/change_form.html" %}
+{% load static %}
+
+{% block extrahead %}
+    {{ block.super }}
+    <script src="{% static "djangocms_versioning/js/object-tools.js" %}"></script>
+{% endblock %}
+
+{% block extrastyle %}
+    {{ block.super }}
+    <link rel="stylesheet" href="{% static "djangocms_versioning/css/object-tools.css" %}">
+{% endblock %}
+
+{% block object-tools-items %}
+    {% include "admin/djangocms_versioning/grouper_versioning_buttons.html" %}
+    {{ block.super }}
+{% endblock %}

--- a/docs/api/advanced_configuration.rst
+++ b/docs/api/advanced_configuration.rst
@@ -231,6 +231,8 @@ Selecting the string ``"__default__"`` will use the
 which combines the functionality of the
 :class:`~djangocms_versioning.admin.StateIndicatorMixin` and the
 :class:`~djangocms_versioning.admin.ExtendedGrouperVersionAdminMixin`.
+This also wires versioning object-tools (Publish / New Draft / Revert /
+Versions) onto the grouper admin change form.
 
 extended_admin_field_modifiers
 ++++++++++++++++++++++++++++++

--- a/docs/explanations/admin_options.rst
+++ b/docs/explanations/admin_options.rst
@@ -182,6 +182,12 @@ For grouper models, use the :class:`~djangocms_versioning.admin.ExtendedGrouperV
     class PostAdmin(ExtendedGrouperVersionAdminMixin, GrouperModelAdmin):
         list_display = ["title", "get_author", "get_modified_date", "get_versioning_state"]
 
+In addition to the changelist fields, the mixin renders versioning object-tools buttons
+on the grouper admin change form — Publish, New Draft, Revert and Versions — mirroring
+those offered on content model admins. Each button is shown only when the underlying
+action is available for the current content object (for example, *New Draft* is only
+offered when the current version is published).
+
 To also add state indicators, include the :class:`~djangocms_versioning.admin.StateIndicatorMixin`:
 
 .. code-block:: python

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -3315,6 +3315,9 @@ class ExtendedVersionGrouperAdminTestCase(CMSTestCase):
 
 class DefaultGrouperAdminTestCase(CMSTestCase):
 
+    def setUp(self):
+        self.versionable = PollsCMSConfig.versioning[0]
+
     def test_get_list_display(self):
         """
         The default grouper admin should return the default list display
@@ -3352,6 +3355,64 @@ class DefaultGrouperAdminTestCase(CMSTestCase):
         self.assertTrue(can_change)
         can_change = modeladmin.can_change_content(request, public_version.content)
         self.assertFalse(can_change)
+
+    def test_change_form_renders_new_draft_for_published_grouper(self):
+        """The grouper admin change view exposes the versioning object-tools,
+        including a 'New Draft' button, when the current content is published.
+        """
+        published = factories.PollVersionFactory(
+            state=constants.PUBLISHED, content__language="en"
+        )
+        modeladmin = admin.site._registry[Poll]
+        modeladmin.language = "en"
+        url = self.get_admin_url(Poll, "change", published.content.poll.pk)
+
+        with self.login_user_context(self.get_superuser()):
+            response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, ">New Draft</a>")
+        # The link targets the version proxy's edit_redirect URL with ?next=
+        edit_redirect_url = self.get_admin_url(
+            self.versionable.version_model_proxy, "edit_redirect", published.pk
+        )
+        self.assertContains(response, f'href="{edit_redirect_url}?next=')
+
+    def test_change_form_no_new_draft_for_draft_grouper(self):
+        """The 'New Draft' button is hidden when the current content is a
+        draft (the action is only offered to branch off a published version).
+        """
+        draft = factories.PollVersionFactory(
+            state=constants.DRAFT, content__language="en"
+        )
+        modeladmin = admin.site._registry[Poll]
+        modeladmin.language = "en"
+        url = self.get_admin_url(Poll, "change", draft.content.poll.pk)
+
+        with self.login_user_context(self.get_superuser()):
+            response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, ">New Draft</a>")
+
+    def test_change_form_exposes_versioning_content_obj(self):
+        """The grouper admin pushes the resolved content object into the
+        template context so the versioning buttons partial can reach it.
+        """
+        version = factories.PollVersionFactory(
+            state=constants.PUBLISHED, content__language="en"
+        )
+        modeladmin = admin.site._registry[Poll]
+        modeladmin.language = "en"
+        url = self.get_admin_url(Poll, "change", version.content.poll.pk)
+
+        with self.login_user_context(self.get_superuser()):
+            response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.context["versioning_content_obj"].pk, version.content.pk
+        )
 
     def test_prepopulated_fields_excluded_when_readonly(self):
         """Prepopulated fields referencing readonly content fields must be

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -2081,7 +2081,7 @@ class EditRedirectTestCase(BaseStateTestCase):
         url = self.get_admin_url(
             page_versionable.version_model_proxy, "edit_redirect", page_version.pk
         )
-        params = {"foo": "bar", "next": "/return/"}
+        params = {"foo": "bar", "baz": "qux"}
 
         with self.login_user_context(self.superuser):
             response = self.client.post(f"{url}?{urlencode(params)}")
@@ -2090,14 +2090,14 @@ class EditRedirectTestCase(BaseStateTestCase):
         self.assertEqual(
             parsed.path, get_object_edit_url(page_version.content, language="en")
         )
-        self.assertEqual(parse_qs(parsed.query), {"foo": ["bar"], "next": ["/return/"]})
+        self.assertEqual(parse_qs(parsed.query), {"foo": ["bar"], "baz": ["qux"]})
 
     def test_edit_redirect_view_drops_get_params_for_admin_redirect(self):
         draft_version = factories.PollVersionFactory(state=constants.DRAFT)
         url = self.get_admin_url(
             self.versionable.version_model_proxy, "edit_redirect", draft_version.pk
         )
-        params = {"force_admin": "1", "next": "/return/"}
+        params = {"force_admin": "1", "foo": "bar"}
 
         with self.login_user_context(self.superuser):
             response = self.client.post(f"{url}?{urlencode(params)}")
@@ -2141,6 +2141,68 @@ class EditRedirectTestCase(BaseStateTestCase):
 
         # no draft was created
         self.assertFalse(Version.objects.filter(state=constants.DRAFT).exists())
+
+    def test_edit_redirect_view_honours_resolvable_next(self):
+        """?next= pointing at a resolvable admin URL takes precedence over
+        the default editable redirect; the draft is still created.
+        """
+        published = factories.PollVersionFactory(state=constants.PUBLISHED)
+        url = self.get_admin_url(
+            self.versionable.version_model_proxy, "edit_redirect", published.pk
+        )
+        next_url = self.get_admin_url(PollContent, "changelist")
+
+        with self.login_user_context(self.get_staff_user_with_no_permissions()):
+            response = self.client.post(f"{url}?{urlencode({'next': next_url})}")
+
+        self.assertRedirects(response, next_url, fetch_redirect_response=False)
+        # Draft was still created
+        self.assertTrue(
+            Version.objects.filter(state=constants.DRAFT).exclude(pk=published.pk).exists()
+        )
+
+    def test_edit_redirect_view_next_honoured_when_draft_exists(self):
+        """?next= is honoured even when a draft already exists; no
+        duplicate draft is created.
+        """
+        published = factories.PollVersionFactory(
+            state=constants.PUBLISHED, content__language="en"
+        )
+        draft = factories.PollVersionFactory(
+            state=constants.DRAFT,
+            content__poll=published.content.poll,
+            content__language="en",
+        )
+        url = self.get_admin_url(
+            self.versionable.version_model_proxy, "edit_redirect", published.pk
+        )
+        next_url = self.get_admin_url(PollContent, "changelist")
+
+        with self.login_user_context(self.get_staff_user_with_no_permissions()):
+            response = self.client.post(f"{url}?{urlencode({'next': next_url})}")
+
+        self.assertRedirects(response, next_url, fetch_redirect_response=False)
+        # No extra draft created
+        self.assertFalse(
+            Version.objects.exclude(pk=draft.pk).filter(state=constants.DRAFT).exists()
+        )
+
+    def test_edit_redirect_view_falls_back_when_next_not_resolvable(self):
+        """A ?next= that doesn't resolve to a known view is ignored in
+        favour of the default editable redirect.
+        """
+        poll_version = factories.PollVersionFactory(state=constants.PUBLISHED)
+        url = self.get_admin_url(
+            self.versionable.version_model_proxy, "edit_redirect", poll_version.pk
+        )
+
+        with self.login_user_context(self.get_staff_user_with_no_permissions()):
+            response = self.client.post(f"{url}?next=http://example.com")
+
+        # Fell back to the content admin change view for non-editable content
+        draft = Version.objects.get(state=constants.DRAFT)
+        expected = self.get_admin_url(PollContent, "change", draft.content.pk)
+        self.assertRedirects(response, expected, target_status_code=302)
 
 
 class CompareViewTestCase(CMSTestCase):


### PR DESCRIPTION
## Description
Adds versioning object-tools buttons (Publish / New Draft / Revert /  to grouper admin change forms, mirroring the content.                         Previously the grouper change view at /admin/<app>/<grouper>/<pk>/change/  had no versioning 

As a prerequisite, edit_redirect_view is brought in line with every action view: it now reads ?next= via _internal_redirect (same publish/revert/archive/discard/unpublish use) instead of the query string as opaque forwarding. This lets the new buttons redirect back to the grouper page after creating a instead of jumping to the content admin.

## Related resources

- https://github.com/django-cms/djangocms-versioning/issues/538#issuecomment-4305102089

## Checklist

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Expose versioning actions in grouper admin change forms and align the edit redirect behaviour with other versioning admin actions.

New Features:
- Add versioning object-tool buttons (Publish, New Draft, Revert, Versions) to grouper admin change forms via a custom change form template and context.
- Introduce a grouper-specific change form template that loads versioning object-tools scripts and styles and injects the buttons into the object-tools area.

Bug Fixes:
- Ensure edit_redirect_view honours a resolvable ?next= parameter consistently with other action views while still creating drafts and avoiding duplicates.
- Fall back to the default editable redirect when ?next= does not resolve to a known admin view, avoiding incorrect external redirects.

Enhancements:
- Expose the resolved content object on grouper admin change views to support rendering versioning controls.
- Refine edit_redirect_view query parameter handling so unrelated GET params are preserved only where appropriate.

Tests:
- Add tests covering edit_redirect_view precedence and fallback behaviour for ?next=, including existing drafts.
- Add tests ensuring grouper change forms render the New Draft control for published content only and expose the versioning content object in the template context.