### PR TITLE
feat: Prepare for Django 6.1 support

### DIFF
--- a/djangocms_versioning/admin.py
+++ b/djangocms_versioning/admin.py
@@ -11,6 +11,7 @@ from cms.utils import get_language_from_request
 from cms.utils.conf import get_cms_setting
 from cms.utils.helpers import is_editable_model
 from cms.utils.urlutils import add_url_parameters, static_with_version
+from django import VERSION as django_VERSION
 from django.conf import settings
 from django.contrib import admin, messages
 from django.contrib.admin.actions import delete_selected
@@ -1483,6 +1484,7 @@ class VersionAdmin(ChangeListActionsMixin, admin.ModelAdmin, metaclass=MediaDefi
             )
             breadcrumb_opts = self.model._source_model._meta
             extra_context["breadcrumb_opts"] = breadcrumb_opts
+            extra_context["new_breadcrumbs"] = django_VERSION >= (6, 1)
             # Check if custom breadcrumb template defined, otherwise
             # fallback on default
             breadcrumb_templates = [

--- a/djangocms_versioning/templates/admin/djangocms_versioning/change_list.html
+++ b/djangocms_versioning/templates/admin/djangocms_versioning/change_list.html
@@ -1,8 +1,2 @@
 {% extends "admin/change_list.html" %}
 {% block breadcrumbs %}{% include breadcrumb_template %}{% endblock %}
-{% block extrastyle %} {# Fixes a bug in django CMS 4.1rc2 - can be deleted as soon as 4.1 is released #}
-    <style>
-        span.cms-empty-action { display: none !important; }
-    </style>
-    {{ block.super }}
-{% endblock %}

--- a/djangocms_versioning/templates/admin/djangocms_versioning/versioning_breadcrumbs.html
+++ b/djangocms_versioning/templates/admin/djangocms_versioning/versioning_breadcrumbs.html
@@ -1,8 +1,18 @@
 {% load i18n admin_urls %}
-<div class="breadcrumbs">
-<a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
-&rsaquo; <a href="{% url 'admin:app_list' app_label=breadcrumb_opts.app_label %}">{{ breadcrumb_opts.app_config.verbose_name }}</a>
-&rsaquo; <a href="{% url breadcrumb_opts|admin_urlname:'changelist' %}">{{ breadcrumb_opts.verbose_name_plural|capfirst }}</a>
-&rsaquo; <a href="{% url breadcrumb_opts|admin_urlname:'change' latest_content.pk|admin_urlquote %}">{{ latest_content|truncatewords:"18" }}</a>
-&rsaquo; {% translate 'Versions' %}
-</div>
+{% if new_breadcrumbs %}
+    <ul class="breadcrumbs">
+        <li><a href="{% url 'admin:index' %}">{% translate 'Home' %}</a></li>
+        <li><a href="{% url 'admin:app_list' app_label=breadcrumb_opts.app_label %}">{{ breadcrumb_opts.app_config.verbose_name }}</a></li>
+        <li><a href="{% url breadcrumb_opts|admin_urlname:'changelist' %}">{{ breadcrumb_opts.verbose_name_plural|capfirst }}</a></li>
+        <li><a href="{% url breadcrumb_opts|admin_urlname:'change' latest_content.pk|admin_urlquote %}">{{ latest_content|truncatewords:"18" }}</a></li>
+        <li aria-current="page">{% translate 'Versions' %}</li>
+    </ul>
+{% else %}
+    <div class="breadcrumbs">
+        <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
+        &rsaquo; <a href="{% url 'admin:app_list' app_label=breadcrumb_opts.app_label %}">{{ breadcrumb_opts.app_config.verbose_name }}</a>
+        &rsaquo; <a href="{% url breadcrumb_opts|admin_urlname:'changelist' %}">{{ breadcrumb_opts.verbose_name_plural|capfirst }}</a>
+        &rsaquo; <a href="{% url breadcrumb_opts|admin_urlname:'change' latest_content.pk|admin_urlquote %}">{{ latest_content|truncatewords:"18" }}</a>
+        &rsaquo; {% translate 'Versions' %}
+    </div>
+{% endif %}

--- a/djangocms_versioning/templates/admin/djangocms_versioning/versioning_breadcrumbs.html
+++ b/djangocms_versioning/templates/admin/djangocms_versioning/versioning_breadcrumbs.html
@@ -1,18 +1,18 @@
 {% load i18n admin_urls %}
 {% if new_breadcrumbs %}
-    <ul class="breadcrumbs">
-        <li><a href="{% url 'admin:index' %}">{% translate 'Home' %}</a></li>
-        <li><a href="{% url 'admin:app_list' app_label=breadcrumb_opts.app_label %}">{{ breadcrumb_opts.app_config.verbose_name }}</a></li>
-        <li><a href="{% url breadcrumb_opts|admin_urlname:'changelist' %}">{{ breadcrumb_opts.verbose_name_plural|capfirst }}</a></li>
-        <li><a href="{% url breadcrumb_opts|admin_urlname:'change' latest_content.pk|admin_urlquote %}">{{ latest_content|truncatewords:"18" }}</a></li>
-        <li aria-current="page">{% translate 'Versions' %}</li>
-    </ul>
+<ul class="breadcrumbs">
+    <li><a href="{% url 'admin:index' %}">{% translate 'Home' %}</a></li>
+    <li><a href="{% url 'admin:app_list' app_label=breadcrumb_opts.app_label %}">{{ breadcrumb_opts.app_config.verbose_name }}</a></li>
+    <li><a href="{% url breadcrumb_opts|admin_urlname:'changelist' %}">{{ breadcrumb_opts.verbose_name_plural|capfirst }}</a></li>
+    <li><a href="{% url breadcrumb_opts|admin_urlname:'change' latest_content.pk|admin_urlquote %}">{{ latest_content|truncatewords:"18" }}</a></li>
+    <li aria-current="page">{% translate 'Versions' %}</li>
+</ul>
 {% else %}
-    <div class="breadcrumbs">
-        <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
-        &rsaquo; <a href="{% url 'admin:app_list' app_label=breadcrumb_opts.app_label %}">{{ breadcrumb_opts.app_config.verbose_name }}</a>
-        &rsaquo; <a href="{% url breadcrumb_opts|admin_urlname:'changelist' %}">{{ breadcrumb_opts.verbose_name_plural|capfirst }}</a>
-        &rsaquo; <a href="{% url breadcrumb_opts|admin_urlname:'change' latest_content.pk|admin_urlquote %}">{{ latest_content|truncatewords:"18" }}</a>
-        &rsaquo; {% translate 'Versions' %}
-    </div>
+<div class="breadcrumbs">
+<a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
+&rsaquo; <a href="{% url 'admin:app_list' app_label=breadcrumb_opts.app_label %}">{{ breadcrumb_opts.app_config.verbose_name }}</a>
+&rsaquo; <a href="{% url breadcrumb_opts|admin_urlname:'changelist' %}">{{ breadcrumb_opts.verbose_name_plural|capfirst }}</a>
+&rsaquo; <a href="{% url breadcrumb_opts|admin_urlname:'change' latest_content.pk|admin_urlquote %}">{{ latest_content|truncatewords:"18" }}</a>
+&rsaquo; {% translate 'Versions' %}
+</div>
 {% endif %}

--- a/djangocms_versioning/templates/admin/djangocms_versioning/versioning_breadcrumbs.html
+++ b/djangocms_versioning/templates/admin/djangocms_versioning/versioning_breadcrumbs.html
@@ -1,12 +1,12 @@
 {% load i18n admin_urls %}
 {% if new_breadcrumbs %}
-<ul class="breadcrumbs">
+<ol class="breadcrumbs">
     <li><a href="{% url 'admin:index' %}">{% translate 'Home' %}</a></li>
     <li><a href="{% url 'admin:app_list' app_label=breadcrumb_opts.app_label %}">{{ breadcrumb_opts.app_config.verbose_name }}</a></li>
     <li><a href="{% url breadcrumb_opts|admin_urlname:'changelist' %}">{{ breadcrumb_opts.verbose_name_plural|capfirst }}</a></li>
     <li><a href="{% url breadcrumb_opts|admin_urlname:'change' latest_content.pk|admin_urlquote %}">{{ latest_content|truncatewords:"18" }}</a></li>
     <li aria-current="page">{% translate 'Versions' %}</li>
-</ul>
+</ol>
 {% else %}
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>

--- a/djangocms_versioning/templates/djangocms_versioning/admin/archive_confirmation.html
+++ b/djangocms_versioning/templates/djangocms_versioning/admin/archive_confirmation.html
@@ -18,15 +18,13 @@
 <h4>{% blocktrans %} Version number: {{ version_number }}{% endblocktrans %}</h4>
 <form action="" method="POST" class="js-close-sideframe">
     {% csrf_token %}
-    <div>
-        <input  class="button confirm-link"
+    <div class="submit-row">
+        <a href="{{ back_url }}" class="button cancel-link js-versioning-keep-sideframe" role="button" style="margin-inline-start: auto">
+            {% translate 'No, take me back' %}
+        </a>
+        <input  class="button confirm-link default"
                 type="submit"
                 value="{% translate "Yes, I'm sure" %}">
-        <a href="{{ back_url }}">
-            <input type="button"
-                   class="button cancel-link js-versioning-keep-sideframe"
-                   value="{% translate 'No, take me back' %}">
-        </a>
     </div>
 </form>
 {% endblock %}

--- a/djangocms_versioning/templates/djangocms_versioning/admin/discard_confirmation.html
+++ b/djangocms_versioning/templates/djangocms_versioning/admin/discard_confirmation.html
@@ -17,14 +17,14 @@
 <h4>{% blocktrans %}Version number: {{ version_number }}{% endblocktrans %}</h4>
 <form action="" method="POST">
     {% csrf_token %}
-    <div>
+    <div class="submit-row">
+        <a href="{{ back_url }}" class="button cancel-link js-versioning-keep-sideframe" role="button" style="margin-inline-start: auto">
+            {% translate 'No, take me back' %}
+        </a>
         <input  class="button confirm-link js-versioning-keep-sideframe default"
                 type="submit"
                 name="discard"
                 value="{% translate "Yes, I'm sure" %}">
-        <a href="{{ back_url }}" class="button cancel-link js-versioning-keep-sideframe" role="button">
-            {% translate 'No, take me back' %}
-        </a>
     </div>
 </form>
 {% endblock %}

--- a/djangocms_versioning/templates/djangocms_versioning/admin/revert_confirmation.html
+++ b/djangocms_versioning/templates/djangocms_versioning/admin/revert_confirmation.html
@@ -27,6 +27,9 @@
     {% csrf_token %}
     <div class="submit-row">
         {% if draft_version %}
+        <a href="{{ back_url }}" class="button cancel-link js-versioning-keep-sideframe" style="margin-inline-start: auto" role="button" style="margin-left: auto">
+            {% translate 'No, take me back' %}
+        </a>
         <input  class="button revert-button confirm-link"
                 type="submit"
                 name="discard"
@@ -36,14 +39,11 @@
                 type="submit"
                 value="{% translate 'Archive existing draft and Revert' %}">
         {% else %}
-        <input  class="button revert-button confirm-link"
+        <input  class="button revert-button confirm-link default"
                 type="submit"
                 name="revert"
                 value="{% translate "Yes, I'm sure" %}">
         {% endif %}
-        <a href="{{ back_url }}" class="cancel-link js-versioning-keep-sideframe" role="button">
-            {% translate 'No, take me back' %}
-        </a>
     </div>
 </form>
 {% endblock %}

--- a/djangocms_versioning/templates/djangocms_versioning/admin/revert_confirmation.html
+++ b/djangocms_versioning/templates/djangocms_versioning/admin/revert_confirmation.html
@@ -26,10 +26,10 @@
 <form action="" method="POST" class="js-close-sideframe">
     {% csrf_token %}
     <div class="submit-row">
-        {% if draft_version %}
-        <a href="{{ back_url }}" class="button cancel-link js-versioning-keep-sideframe" style="margin-inline-start: auto" role="button" style="margin-left: auto">
+        <a href="{{ back_url }}" class="button cancel-link js-versioning-keep-sideframe" style="margin-inline-start: auto" role="button">
             {% translate 'No, take me back' %}
         </a>
+        {% if draft_version %}
         <input  class="button revert-button confirm-link"
                 type="submit"
                 name="discard"

--- a/djangocms_versioning/templates/djangocms_versioning/admin/unpublish_confirmation.html
+++ b/djangocms_versioning/templates/djangocms_versioning/admin/unpublish_confirmation.html
@@ -12,7 +12,7 @@
 {% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} delete-confirmation{% endblock %}
 
 {% block content %}
-<h1>{% block title %}{% translate "Revert Confirmation" %}{% endblock %}</h1>
+<h1>{% block title %}{% translate "Unpublish Confirmation" %}{% endblock %}</h1>
 <p>{% translate "Unpublishing will remove this version from live. Are you sure you want to unpublish?" %}</p>
 <h3>{{ object_name }}</h3>
 <h4>{% blocktrans %} Version number: {{ version_number }}{% endblocktrans %}</h4>
@@ -24,14 +24,12 @@
 <form action="" method="POST" class="js-close-sideframe">
     {% csrf_token %}
     <div class="submit-row">
-        <input  class="button confirm-link"
+        <a href="{{ back_url }}" class="button cancel-link js-versioning-keep-sideframe" role="button" style="margin-inline-start: auto">
+            {% translate 'No, take me back' %}
+        </a>
+        <input  class="button confirm-link default"
                 type="submit"
                 value="{% translate "Yes, I'm sure" %}">
-        <a href="{{ back_url }}">
-            <input type="button"
-                   class="button js-versioning-keep-sideframe"
-                   value="{% translate 'No, take me back' %}">
-        </a>
     </div>
 </form>
 {% endblock %}

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -2448,14 +2448,16 @@ class VersionChangeListViewTestCase(CMSTestCase):
             expected = """<ol class="breadcrumbs">\\n    <li><a href="/en/admin/">Home</a></li>\\n"""
             expected += """    <li><a href="/en/admin/polls/">Polls</a></li>\\n"""
             expected += """    <li><a href="/en/admin/polls/pollcontent/">Poll contents</a></li>\\n"""
-            expected += f"""    <li><a href="/en/admin/polls/pollcontent/{poll_content.pk}/change/">{str(poll_content)}</a></li>\\n"""
-            expected += """    <li aria-current="page">Versions</li>\\n</ol>"""            
+            expected += f"""    <li><a href="/en/admin/polls/pollcontent/{poll_content.pk}/change/">"""
+            expected += f"""{str(poll_content)}</a></li>\\n"""
+            expected += """    <li aria-current="page">Versions</li>\\n</ol>"""
         else:
             breadcrumb_html = soup.find("div", class_="breadcrumbs")
             expected = """<div class="breadcrumbs">\\n<a href="/en/admin/">Home</a>\\n› """
             expected += """<a href="/en/admin/polls/">Polls</a>\\n› """
             expected += """<a href="/en/admin/polls/pollcontent/">Poll contents</a>\\n› """
-            expected += f"""<a href="/en/admin/polls/pollcontent/{poll_content.pk}/change/">{str(poll_content)}</a>\\n› """
+            expected += f"""<a href="/en/admin/polls/pollcontent/{poll_content.pk}/change/">"""
+            expected += f"""{str(poll_content)}</a>\\n› """
             expected += """Versions\\n</div>"""
         # Assert the breadcrumbs
         self.assertEqual(str(breadcrumb_html), expected)
@@ -2463,7 +2465,6 @@ class VersionChangeListViewTestCase(CMSTestCase):
     def test_changelist_view_displays_correct_breadcrumbs_when_app_defines_breadcrumbs(
         self
     ):
-        from django import VERSION as DJANGO_VERSION
 
         # The blogpost test app defines a breadcrumb template in
         # templates/admin/djangocms_versioning/blogpost/blogcontent/versioning_breadcrumbs.html
@@ -3506,8 +3507,6 @@ class GrouperAdminPerformanceTestCase(CMSTestCase):
 
     def test_poll_grouper_changelist_queries_are_optimized(self):
         """Pin the number of queries for Poll GrouperAdmin changelist to prevent regressions"""
-        from djangocms_versioning import __version__ as cms_version
-
         # Create test data: 5 polls with 2 versions each (draft + published)
         for _i in range(5):
             # Create published version

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -3566,6 +3566,6 @@ class GrouperAdminPerformanceTestCase(CMSTestCase):
 
         # Query count should remain the same regardless of version count
         # because of prefetch optimization
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(3 if cms_version < "5.1" else 4):
             response = poll_admin.changelist_view(request)
             list(response.context_data["cl"].result_list)

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -2432,6 +2432,8 @@ class VersionChangeListViewTestCase(CMSTestCase):
         self.assertEqual(fr_version1.content, fr_response.context["cl"].queryset.first().content)
 
     def test_changelist_view_displays_correct_breadcrumbs(self):
+        from django import VERSION as DJANGO_VERSION
+
         poll_content = factories.PollContentWithVersionFactory()
         url = self.get_admin_url(self.versionable.version_model_proxy, "changelist")
         url += "?poll=" + str(poll_content.poll_id)
@@ -2441,18 +2443,28 @@ class VersionChangeListViewTestCase(CMSTestCase):
 
         # Traverse the returned html to find the breadcrumbs
         soup = BeautifulSoup(str(response.content), features="lxml")
-        breadcrumb_html = soup.find("div", class_="breadcrumbs")
+        if DJANGO_VERSION >= (6, 1):
+            breadcrumb_html = soup.find("ol", class_="breadcrumbs")
+            expected = """<ol class="breadcrumbs">\\n    <li><a href="/en/admin/">Home</a></li>\\n"""
+            expected += """    <li><a href="/en/admin/polls/">Polls</a></li>\\n"""
+            expected += """    <li><a href="/en/admin/polls/pollcontent/">Poll contents</a></li>\\n"""
+            expected += f"""    <li><a href="/en/admin/polls/pollcontent/{poll_content.pk}/change/">{str(poll_content)}</a></li>\\n"""
+            expected += """    <li aria-current="page">Versions</li>\\n</ol>"""            
+        else:
+            breadcrumb_html = soup.find("div", class_="breadcrumbs")
+            expected = """<div class="breadcrumbs">\\n<a href="/en/admin/">Home</a>\\n› """
+            expected += """<a href="/en/admin/polls/">Polls</a>\\n› """
+            expected += """<a href="/en/admin/polls/pollcontent/">Poll contents</a>\\n› """
+            expected += f"""<a href="/en/admin/polls/pollcontent/{poll_content.pk}/change/">{str(poll_content)}</a>\\n› """
+            expected += """Versions\\n</div>"""
         # Assert the breadcrumbs
-        expected = """<div class="breadcrumbs">\\n<a href="/en/admin/">Home</a>\\n› """
-        expected += """<a href="/en/admin/polls/">Polls</a>\\n› """
-        expected += """<a href="/en/admin/polls/pollcontent/">Poll contents</a>\\n› """
-        expected += f"""<a href="/en/admin/polls/pollcontent/{poll_content.pk}/change/">{str(poll_content)}</a>\\n› """
-        expected += """Versions\\n</div>"""
         self.assertEqual(str(breadcrumb_html), expected)
 
     def test_changelist_view_displays_correct_breadcrumbs_when_app_defines_breadcrumbs(
         self
     ):
+        from django import VERSION as DJANGO_VERSION
+
         # The blogpost test app defines a breadcrumb template in
         # templates/admin/djangocms_versioning/blogpost/blogcontent/versioning_breadcrumbs.html
         # This test checks that template gets used.
@@ -2463,17 +2475,15 @@ class VersionChangeListViewTestCase(CMSTestCase):
 
         with self.login_user_context(self.superuser):
             response = self.client.get(url)
-
-        # Traverse the returned html to find the breadcrumbs
-        soup = BeautifulSoup(str(response.content), features="lxml")
-        breadcrumb_html = soup.find("div", class_="breadcrumbs")
         # Assert the breadcrumbs
         expected = """<div class="breadcrumbs">Blog post breadcrumbs bla bla</div>"""
-        self.assertEqual(str(breadcrumb_html), expected)
+        self.assertContains(response, expected)
 
     def test_changelist_view_displays_correct_breadcrumbs_for_extra_grouping_values(
         self
     ):
+        from django import VERSION as DJANGO_VERSION
+
         with freeze_time("1999-09-09"):
             # Make sure the English version is older than the French
             # So that the French one is in fact the latest one
@@ -2492,15 +2502,24 @@ class VersionChangeListViewTestCase(CMSTestCase):
 
         # Traverse the returned html to find the breadcrumbs
         soup = BeautifulSoup(str(response.content), features="lxml")
-        breadcrumb_html = soup.find("div", class_="breadcrumbs")
         # Assert the breadcrumbs - we should have ignored the French one
         # and put the English one in the breadcrumbs
         pk = page_content_en.pk
-        expected = """<div class="breadcrumbs">\\n<a href="/en/admin/">Home</a>\\n› """
-        expected += """<a href="/en/admin/cms/">django CMS</a>\\n› """
-        expected += """<a href="/en/admin/cms/pagecontent/">Page contents</a>\\n› """
-        expected += f"""<a href="/en/admin/cms/pagecontent/{pk}/change/">{page_content_en}</a>\\n› """
-        expected += """Versions\\n</div>"""
+        if DJANGO_VERSION >= (6, 1):
+            breadcrumb_html = soup.find("ol", class_="breadcrumbs")
+            expected = """<ol class="breadcrumbs">\\n    <li><a href="/en/admin/">Home</a></li>\\n"""
+            expected += """    <li><a href="/en/admin/cms/">django CMS</a></li>\\n"""
+            expected += """    <li><a href="/en/admin/cms/pagecontent/">Page contents</a></li>\\n"""
+            expected += f"""    <li><a href="/en/admin/cms/pagecontent/{pk}/change/">{page_content_en}</a></li>\\n"""
+            expected += """    <li aria-current="page">Versions</li>\\n</ol>"""
+        else:
+            breadcrumb_html = soup.find("div", class_="breadcrumbs")
+            expected = """<div class="breadcrumbs">\\n<a href="/en/admin/">Home</a>\\n› """
+            expected += """<a href="/en/admin/cms/">django CMS</a>\\n› """
+            expected += """<a href="/en/admin/cms/pagecontent/">Page contents</a>\\n› """
+            expected += f"""<a href="/en/admin/cms/pagecontent/{pk}/change/">{page_content_en}</a>\\n› """
+            expected += """Versions\\n</div>"""
+
         self.assertEqual(str(breadcrumb_html), expected)
 
     def test_changelist_view_redirects_on_url_params_that_arent_grouping_params(self):

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -3506,6 +3506,8 @@ class GrouperAdminPerformanceTestCase(CMSTestCase):
 
     def test_poll_grouper_changelist_queries_are_optimized(self):
         """Pin the number of queries for Poll GrouperAdmin changelist to prevent regressions"""
+        from djangocms_versioning import __version__ as cms_version
+
         # Create test data: 5 polls with 2 versions each (draft + published)
         for _i in range(5):
             # Create published version
@@ -3533,7 +3535,8 @@ class GrouperAdminPerformanceTestCase(CMSTestCase):
         # 1. Count query for pagination
         # 2. Count query (duplicate from admin)
         # 3. Main queryset with subqueries for content annotations
-        with self.assertNumQueries(3):
+        # 4. django CMS 5.1+: Prefetch content
+        with self.assertNumQueries(3 if cms_version < "5.1" else 4):
             response = poll_admin.changelist_view(request)
             # Force evaluation of queryset
             list(response.context_data["cl"].result_list)


### PR DESCRIPTION

## Summary by Sourcery

Align versioning admin templates and breadcrumbs with modern Django admin patterns while preserving backward compatibility.

Enhancements:
- Update versioning breadcrumbs template to use the new list-based breadcrumb markup when running on Django 6.1 or newer, with a fallback to the legacy markup for older versions.
- Standardize archive, unpublish, discard, and revert confirmation templates to use Django admin submit-row layout, semantic cancel links, and default primary action styling.
- Correct the unpublish confirmation page title text to accurately describe the action.
- Remove obsolete inline CSS workaround from the versioning change list admin template now that the underlying issue is resolved.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
