### PR TITLE
fix: Enforced change permission on discard and edit_redirect

### DIFF
--- a/djangocms_versioning/models.py
+++ b/djangocms_versioning/models.py
@@ -32,6 +32,7 @@ except ImportError:
 not_draft_error = _("This version is not a draft: to make changes create a new draft")
 lock_error_message = _("The latest version is locked by {user}")
 lock_draft_error_message = _("The draft version is locked by {user}")
+change_permission_error = _("You do not have change permissions")
 permission_error_message = _("You do not have permission to perform this action")
 
 
@@ -305,7 +306,7 @@ class Version(models.Model):
 
     check_archive = Conditions(
         [
-            user_can_change(_("You do not have change permissions")),
+            user_can_change(change_permission_error),
             in_state([constants.DRAFT], _("Version is not in draft state")),
             is_not_locked(lock_error_message),
         ]
@@ -525,7 +526,7 @@ class Version(models.Model):
     )
     check_revert = Conditions(
         [
-            user_can_change(_("You do not have change permissions")),
+            user_can_change(change_permission_error),
             in_state(
                 [constants.ARCHIVED, constants.UNPUBLISHED],
                 _("Version is not in archived or unpublished state"),
@@ -536,6 +537,7 @@ class Version(models.Model):
     check_discard = Conditions(
         [
             in_state([constants.DRAFT], not_draft_error),
+            user_can_change(change_permission_error),
             is_not_locked(lock_error_message),
         ]
     )
@@ -545,6 +547,7 @@ class Version(models.Model):
                 [constants.DRAFT, constants.PUBLISHED],
                 _("Version is not in draft or published state"),
             ),
+            user_can_change(change_permission_error),
             draft_is_not_locked(lock_draft_error_message),
         ]
     )

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -473,7 +473,7 @@ class VersionAdminActionsTestCase(CMSTestCase):
         """
         version = factories.PollVersionFactory(state=constants.DRAFT)
         request = RequestFactory().get("/admin/polls/pollcontent/")
-        request.user = factories.UserFactory()
+        request.user = self.get_superuser()
         expected_disabled_control = "inactive"
         expected_href = self.get_admin_url(
             self.versionable.version_model_proxy, "edit_redirect", version.pk
@@ -496,7 +496,7 @@ class VersionAdminActionsTestCase(CMSTestCase):
         """
         version = factories.PollVersionFactory(state=constants.DRAFT)
         request = RequestFactory().get("/admin/polls/pollcontent/")
-        request.user = factories.UserFactory()
+        request.user = self.get_superuser()
         expected_disabled_control = "inactive"
         expected_href = None
 
@@ -682,7 +682,7 @@ class VersionAdminActionsTestCase(CMSTestCase):
         """
         version = factories.PageVersionFactory(state=constants.DRAFT)
         request = RequestFactory().get("/")
-        request.user = factories.UserFactory()
+        request.user = self.get_superuser()
         expected_sideframe_open_control = "js-keep-sideframe"
         expected_sideframe_close_control = "js-close-sideframe"
         expected_href = self.get_admin_url(
@@ -707,7 +707,7 @@ class VersionAdminActionsTestCase(CMSTestCase):
         """
         version = factories.PollVersionFactory(state=constants.DRAFT)
         request = RequestFactory().get("/admin/polls/pollcontent/")
-        request.user = factories.UserFactory()
+        request.user = self.get_superuser()
         expected_sideframe_open_control = "js-keep-sideframe"
         expected_sideframe_close_control = "js-close-sideframe"
         expected_href = self.get_admin_url(
@@ -1898,6 +1898,7 @@ class EditRedirectTestCase(BaseStateTestCase):
             self.versionable.version_model_proxy, "edit_redirect", published.pk
         )
         user = self.get_staff_user_with_no_permissions()
+        user.user_permissions.add(self.get_permission("change_pollcontent"))
 
         with self.login_user_context(user):
             response = self.client.post(url)
@@ -1924,6 +1925,7 @@ class EditRedirectTestCase(BaseStateTestCase):
             self.versionable.version_model_proxy, "edit_redirect", draft.pk
         )
         user = self.get_staff_user_with_no_permissions()
+        user.user_permissions.add(self.get_permission("change_pollcontent"))
 
         with self.login_user_context(user):
             response = self.client.post(url)
@@ -1949,6 +1951,7 @@ class EditRedirectTestCase(BaseStateTestCase):
             self.versionable.version_model_proxy, "edit_redirect", draft.pk
         )
         user = self.get_staff_user_with_no_permissions()
+        user.user_permissions.add(self.get_permission("change_pollcontent"))
 
         with self.login_user_context(user):
             response = self.client.post(url)
@@ -2019,8 +2022,10 @@ class EditRedirectTestCase(BaseStateTestCase):
         url = self.get_admin_url(
             self.versionable.version_model_proxy, "edit_redirect", published.pk
         )
+        user = self.get_staff_user_with_no_permissions()
+        user.user_permissions.add(self.get_permission("change_pollcontent"))
 
-        with self.login_user_context(self.get_staff_user_with_no_permissions()):
+        with self.login_user_context(user):
             response = self.client.post(url)
 
         # redirect happened
@@ -3529,8 +3534,8 @@ class ListActionsTestCase(CMSTestCase):
         edit_endpoint = reverse("admin:djangocms_versioning_blogcontentversion_edit_redirect", args=(version.pk,),)
         response = func(version.content)
 
-        self.assertIn("inactive", response)
-        self.assertIn('title="Edit"', response)
+        # Without change permission the edit action is not offered at all
+        self.assertNotIn('title="Edit"', response)
         self.assertNotIn(edit_endpoint, response)
 
     def test_valid_back_link(self):

--- a/tests/test_locking.py
+++ b/tests/test_locking.py
@@ -262,7 +262,7 @@ class VersionLockUnlockTestCase(CMSTestCase):
     @classmethod
     def setUpTestData(cls):
         cls.versionable = PollsCMSConfig.versioning[0]
-        cls.default_permissions = ["change_pollcontentversion"]
+        cls.default_permissions = ["change_pollcontentversion", "change_pollcontent"]
 
     def setUp(self):
         import importlib

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -257,3 +257,90 @@ class PermissionTestCase(BaseStateTestCase):
         self.assertIsNotNone(post_version_)
         self.assertEqual(post_version_.state, constants.DRAFT)
         self.assertTrue(post_version_.content.has_change_permission(user))  # Content was copied
+
+    @patch("django.contrib.messages.add_message")
+    def test_discard_view_cannot_be_accessed_without_permission(
+        self, mocked_messages
+    ):
+        # Regression test: discarding a draft (which deletes the underlying
+        # content object) must require change permission. A staff user without
+        # it must not be able to discard someone else's draft via its version pk.
+        post_version = factories.BlogPostVersionFactory(state=constants.DRAFT)
+        url = self.get_admin_url(
+            self.versionable.version_model_proxy, "discard", post_version.pk
+        )
+        user = self.get_staff_user_with_no_permissions()
+
+        with self.login_user_context(user):
+            self.client.post(url, data={"discard": "1"})
+
+        self.assertEqual(mocked_messages.call_count, 1)
+        self.assertEqual(mocked_messages.call_args[0][1], messages.ERROR)
+        self.assertEqual(mocked_messages.call_args[0][2], "You do not have change permissions")
+
+        # The version (and its content) has not been discarded
+        self.assertTrue(Version.objects.filter(pk=post_version.pk).exists())
+
+    @patch("django.contrib.messages.add_message")
+    def test_discard_view_can_be_accessed_with_permission(
+        self, mocked_messages
+    ):
+        poll_version = factories.PollVersionFactory(state=constants.DRAFT)
+        url = self.get_admin_url(
+            self.poll_versionable.version_model_proxy, "discard", poll_version.pk
+        )
+        user = self.get_staff_user_with_no_permissions()
+        user.user_permissions.add(self.get_permission("change_pollcontent"))
+
+        with self.login_user_context(user):
+            self.client.post(url, data={"discard": "1"})
+
+        # The version has been discarded
+        self.assertFalse(Version.objects.filter(pk=poll_version.pk).exists())
+
+    @patch("django.contrib.messages.add_message")
+    def test_edit_redirect_view_cannot_be_accessed_without_permission(
+        self, mocked_messages
+    ):
+        # Regression test: creating a draft off a published version via
+        # edit_redirect must require change permission.
+        post_version = factories.BlogPostVersionFactory(state=constants.PUBLISHED)
+        url = self.get_admin_url(
+            self.versionable.version_model_proxy, "edit_redirect", post_version.pk
+        )
+        user = self.get_staff_user_with_no_permissions()
+
+        with self.login_user_context(user):
+            self.client.post(url)
+
+        self.assertEqual(mocked_messages.call_count, 1)
+        self.assertEqual(mocked_messages.call_args[0][1], messages.ERROR)
+        self.assertEqual(mocked_messages.call_args[0][2], "You do not have change permissions")
+
+        # No draft was created
+        self.assertFalse(
+            Version.objects.filter(
+                content_type=post_version.content_type, state=constants.DRAFT
+            ).exists()
+        )
+
+    @patch("django.contrib.messages.add_message")
+    def test_edit_redirect_view_can_be_accessed_with_permission(
+        self, mocked_messages
+    ):
+        poll_version = factories.PollVersionFactory(state=constants.PUBLISHED)
+        url = self.get_admin_url(
+            self.poll_versionable.version_model_proxy, "edit_redirect", poll_version.pk
+        )
+        user = self.get_staff_user_with_no_permissions()
+        user.user_permissions.add(self.get_permission("change_pollcontent"))
+
+        with self.login_user_context(user):
+            self.client.post(url)
+
+        # A draft was created off the published version
+        self.assertTrue(
+            Version.objects.filter(
+                content_type=poll_version.content_type, state=constants.DRAFT
+            ).exists()
+        )


### PR DESCRIPTION
## Summary by Sourcery

Enforce change permissions for version discard and edit_redirect actions and align related admin behavior and tests.

Bug Fixes:
- Require change permission when discarding draft versions to prevent unauthorized deletion of content.
- Require change permission when creating drafts via edit_redirect to prevent unauthorized draft creation.
- Ensure the edit action link is not rendered for users without change permission, rather than showing an inactive link.

Enhancements:
- Introduce a shared change permission error message for versioning permission checks.
- Extend default locking-related permissions to include content change permission where necessary.

Tests:
- Add regression tests covering discard and edit_redirect access with and without change permissions.
- Adjust admin and locking tests to reflect the new permission requirements and edit link visibility.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.