### PR TITLE
chore: Update GrouperAdminMixin for CMS 5.2 compat

### DIFF
--- a/djangocms_versioning/admin.py
+++ b/djangocms_versioning/admin.py
@@ -67,11 +67,25 @@ from .versionables import _cms_extension
 
 
 def _get_grouper_content_filters(model_admin, request):
+    versionable = versionables.for_grouper(model_admin.model)
     if hasattr(model_admin, "get_content_filters"):
-        return model_admin.get_content_filters(request)
-    # Compatibility with django CMS < 5.1. Drop when django CMS 5.0 support is dropped.
-    model_admin.get_grouping_from_request(request)
-    return model_admin.current_content_filters
+        content_filters = model_admin.get_content_filters(request)
+    else:
+        # Compatibility with django CMS < 5.1. Drop when django CMS 5.0 support is dropped.
+        model_admin.get_grouping_from_request(request)
+        content_filters = model_admin.current_content_filters
+
+    content_filters = dict(content_filters)
+    for field in versionable.extra_grouping_fields:
+        if field in content_filters:
+            continue
+        if hasattr(model_admin, f"get_{field}_from_request"):
+            content_filters[field] = getattr(model_admin, f"get_{field}_from_request")(request)
+        elif field == "language":
+            content_filters[field] = get_language_from_request(request)
+        elif hasattr(model_admin, field):
+            content_filters[field] = getattr(model_admin, field)
+    return content_filters
 
 
 class VersioningChangeListMixin:

--- a/djangocms_versioning/admin.py
+++ b/djangocms_versioning/admin.py
@@ -66,6 +66,14 @@ from .models import Version
 from .versionables import _cms_extension
 
 
+def _get_grouper_content_filters(model_admin, request):
+    if hasattr(model_admin, "get_content_filters"):
+        return model_admin.get_content_filters(request)
+    # Compatibility with django CMS < 5.1. Drop when django CMS 5.0 support is dropped.
+    model_admin.get_grouping_from_request(request)
+    return model_admin.current_content_filters
+
+
 class VersioningChangeListMixin:
     """Mixin used for ChangeList classes of content models."""
 
@@ -182,13 +190,17 @@ class StateIndicatorMixin(metaclass=MediaDefiningClass):
             return None
 
     def get_indicator_column(self, request):
+        grouping_filters = None
+        if self._extra_grouping_fields is not None:
+            grouping_filters = _get_grouper_content_filters(self, request)
+
         def indicator(obj):
             versions = None
             if self._extra_grouping_fields is not None:  # Grouper Model
                 content_obj = get_latest_admin_viewable_content(
                     obj,
                     include_unpublished_archived=True,
-                    **{field: getattr(self, field) for field in self._extra_grouping_fields},
+                    **grouping_filters,
                 )
                 for prefetched in getattr(obj, "_prefetched_contents", []):
                     prefetched._prefetched_versions[0].content = prefetched  # Avoid fetching reverse
@@ -257,10 +269,11 @@ class ExtendedListDisplayMixin:
 
     def _get_field_modifier(self, request, modifier_dict, field):
         method = modifier_dict[field]
+        content_filters = _get_grouper_content_filters(self, request) if self._is_grouper_admin else None
 
         def get_field_modifier(obj):
             if self._is_grouper_admin:  # In a grouper admin?
-                return method(self.get_content_obj(obj), field)
+                return method(self.get_content_obj(obj, content_filters=content_filters), field)
             else:
                 return method(obj, field)
 
@@ -324,10 +337,11 @@ class ExtendedGrouperVersionAdminMixin(ExtendedListDisplayMixin):
         """Annotates the username of the ``created_by`` field, the ``modified`` field (date time),
         and the ``state`` field of the version object to the grouper queryset."""
         grouper_content_type = versionables.for_grouper(self.model).content_types
+        content_filters = _get_grouper_content_filters(self, request)
         qs = super().get_queryset(request)
         versions = Version.objects.filter(object_id=OuterRef("pk"), content_type__in=grouper_content_type)
         contents = self.content_model.admin_manager.latest_content(
-            **{self.grouper_field_name: OuterRef("pk"), **self.current_content_filters}
+            **{self.grouper_field_name: OuterRef("pk"), **content_filters}
         ).annotate(
             content_created_by=Subquery(versions.values(f"created_by__{conf.USERNAME_FIELD}")[:1]),
             content_state=Subquery(versions.values("state")),
@@ -349,7 +363,7 @@ class ExtendedGrouperVersionAdminMixin(ExtendedListDisplayMixin):
             Prefetch(
                 reverse_name,
                 to_attr="_prefetched_contents",  # Needed for state indicators
-                queryset=self.content_model.admin_manager.filter(**self.current_content_filters)
+                queryset=self.content_model.admin_manager.filter(**content_filters)
                 .prefetch_related(Prefetch("versions", to_attr="_prefetched_versions"))
                 .annotate(content_is_latest=Value(True))  # We're only looking at the latest content in the qs
                 .order_by("-pk"),
@@ -357,13 +371,16 @@ class ExtendedGrouperVersionAdminMixin(ExtendedListDisplayMixin):
         )
         return qs
 
-    def get_content_obj(self, obj: models.Model) -> models.Model:
+    def get_content_obj(self, obj: models.Model, content_filters: dict | None = None) -> models.Model:
         """Returns the latest content object for the given grouper object."""
         if obj is None or obj.pk is None:
             # Unsaved grouper instances (e.g. on the admin add view) have no content object
             # and are unhashable, so they must not reach the instance-keyed cache in the super().
             return None
         if self._is_content_obj(obj) or not hasattr(obj, "_prefetched_contents"):
+            if hasattr(self, "get_content_filters"):
+                return super().get_content_obj(obj, content_filters=content_filters)
+            # Compatibility with django CMS < 5.1. Drop when django CMS 5.0 support is dropped.
             return super().get_content_obj(obj)
         return get_latest_content_from_cache(obj._prefetched_contents, include_unpublished_archived=True)
 
@@ -425,10 +442,7 @@ class ExtendedGrouperVersionAdminMixin(ExtendedListDisplayMixin):
         would raise a KeyError in ``AdminForm.__init__``. Filter against the actual form
         fields so both the key and every dependency are guaranteed to resolve.
         """
-        # Ensure the per-request content cache is refreshed before get_form() queries
-        # readonly state. changeform_view() calls this too, but direct callers (and tests)
-        # exercise get_prepopulated_fields in isolation.
-        self.get_grouping_from_request(request)
+        _get_grouper_content_filters(self, request)
         prepopulated_fields = super().get_prepopulated_fields(request, obj)
         if not prepopulated_fields:
             return prepopulated_fields

--- a/djangocms_versioning/admin.py
+++ b/djangocms_versioning/admin.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import warnings
 from collections import OrderedDict
+from inspect import Parameter, signature
 from urllib.parse import urlencode, urlparse
 
 from cms.admin.utils import CONTENT_PREFIX, ChangeListActionsMixin, GrouperModelAdmin
@@ -86,6 +87,19 @@ def _get_grouper_content_filters(model_admin, request):
         elif hasattr(model_admin, field):
             content_filters[field] = getattr(model_admin, field)
     return content_filters
+
+
+def _accepts_content_filters(method):
+    return any(
+        parameter.kind == Parameter.VAR_KEYWORD or parameter.name == "content_filters"
+        for parameter in signature(method).parameters.values()
+    )
+
+
+def _get_grouper_content_obj(model_admin, obj, content_filters=None):
+    if _accepts_content_filters(model_admin.get_content_obj):
+        return model_admin.get_content_obj(obj, content_filters=content_filters)
+    return model_admin.get_content_obj(obj)
 
 
 class VersioningChangeListMixin:
@@ -287,7 +301,7 @@ class ExtendedListDisplayMixin:
 
         def get_field_modifier(obj):
             if self._is_grouper_admin:  # In a grouper admin?
-                return method(self.get_content_obj(obj, content_filters=content_filters), field)
+                return method(_get_grouper_content_obj(self, obj, content_filters=content_filters), field)
             else:
                 return method(obj, field)
 
@@ -392,10 +406,11 @@ class ExtendedGrouperVersionAdminMixin(ExtendedListDisplayMixin):
             # and are unhashable, so they must not reach the instance-keyed cache in the super().
             return None
         if self._is_content_obj(obj) or not hasattr(obj, "_prefetched_contents"):
-            if hasattr(self, "get_content_filters"):
-                return super().get_content_obj(obj, content_filters=content_filters)
+            get_content_obj = super().get_content_obj
+            if _accepts_content_filters(get_content_obj):
+                return get_content_obj(obj, content_filters=content_filters)
             # Compatibility with django CMS < 5.1. Drop when django CMS 5.0 support is dropped.
-            return super().get_content_obj(obj)
+            return get_content_obj(obj)
         return get_latest_content_from_cache(obj._prefetched_contents, include_unpublished_archived=True)
 
     @admin.display(

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -32,9 +32,12 @@ from freezegun import freeze_time
 import djangocms_versioning.helpers
 from djangocms_versioning import constants, helpers
 from djangocms_versioning.admin import (
+    ExtendedGrouperVersionAdminMixin,
     VersionAdmin,
     VersionChangeList,
     VersioningAdminMixin,
+    _get_grouper_content_filters,
+    _get_grouper_content_obj,
 )
 from djangocms_versioning.cms_config import VersioningCMSConfig
 from djangocms_versioning.helpers import (
@@ -3155,6 +3158,116 @@ class ExtendedVersionGrouperAdminTestCase(CMSTestCase):
         modified_field = modeladmin._get_field_modifier(request, modifier_dict, "text")
 
         self.assertEqual("{} {}".format(content.text, "Test!"), modified_field(content))
+
+    def test_get_content_obj_supports_old_grouper_admin_api(self):
+        class OldGrouperAdminBase:
+            def get_content_obj(self, obj):
+                return obj
+
+        class VersionedOldGrouperAdmin(ExtendedGrouperVersionAdminMixin, OldGrouperAdminBase):
+            def _is_content_obj(self, obj):
+                return False
+
+        class Obj:
+            pk = 1
+
+        obj = Obj()
+        modeladmin = VersionedOldGrouperAdmin()
+
+        self.assertIs(
+            modeladmin.get_content_obj(obj, content_filters={"language": "en"}),
+            obj,
+        )
+
+    def test_get_content_obj_passes_content_filters_to_new_grouper_admin_api(self):
+        class NewGrouperAdminBase:
+            def get_content_obj(self, obj, content_filters=None):
+                self.content_filters = content_filters
+                return obj
+
+        class VersionedNewGrouperAdmin(ExtendedGrouperVersionAdminMixin, NewGrouperAdminBase):
+            def _is_content_obj(self, obj):
+                return False
+
+        class Obj:
+            pk = 1
+
+        obj = Obj()
+        modeladmin = VersionedNewGrouperAdmin()
+        content_filters = {"language": "en"}
+
+        self.assertIs(
+            modeladmin.get_content_obj(obj, content_filters=content_filters),
+            obj,
+        )
+        self.assertEqual(modeladmin.content_filters, content_filters)
+
+    def test_get_grouper_content_obj_supports_old_grouper_admin_api(self):
+        class OldGrouperAdmin:
+            def get_content_obj(self, obj):
+                self.called_with = obj
+                return obj
+
+        obj = object()
+        modeladmin = OldGrouperAdmin()
+
+        self.assertIs(
+            _get_grouper_content_obj(modeladmin, obj, content_filters={"language": "en"}),
+            obj,
+        )
+        self.assertIs(modeladmin.called_with, obj)
+
+    def test_get_grouper_content_obj_passes_filters_to_new_grouper_admin_api(self):
+        class NewGrouperAdmin:
+            def get_content_obj(self, obj, content_filters=None):
+                self.called_with = obj
+                self.content_filters = content_filters
+                return obj
+
+        obj = object()
+        modeladmin = NewGrouperAdmin()
+        content_filters = {"language": "en"}
+
+        self.assertIs(
+            _get_grouper_content_obj(modeladmin, obj, content_filters=content_filters),
+            obj,
+        )
+        self.assertIs(modeladmin.called_with, obj)
+        self.assertEqual(modeladmin.content_filters, content_filters)
+
+    def test_get_grouper_content_filters_supports_old_grouper_admin_api(self):
+        class OldGrouperAdmin:
+            model = Poll
+
+            def get_grouping_from_request(self, request):
+                self.grouping_request = request
+                self.current_content_filters = {"language": "en"}
+
+        request = self.get_request("/")
+        modeladmin = OldGrouperAdmin()
+
+        self.assertEqual(
+            _get_grouper_content_filters(modeladmin, request),
+            {"language": "en"},
+        )
+        self.assertIs(modeladmin.grouping_request, request)
+
+    def test_get_grouper_content_filters_supports_new_grouper_admin_api(self):
+        class NewGrouperAdmin:
+            model = Poll
+
+            def get_content_filters(self, request):
+                self.filters_request = request
+                return {"language": "en"}
+
+        request = self.get_request("/")
+        modeladmin = NewGrouperAdmin()
+
+        self.assertEqual(
+            _get_grouper_content_filters(modeladmin, request),
+            {"language": "en"},
+        )
+        self.assertIs(modeladmin.filters_request, request)
 
     def test_extended_grouper_extend_list_display_handles_non_existent_field(self):
         """


### PR DESCRIPTION
## Summary by Sourcery

Improve versioning admin grouper handling to be compatible with django CMS 5.1 while retaining support for earlier versions.

Enhancements:
- Introduce a shared helper to resolve grouper content filters across different django CMS versions.
- Update grouper-related queryset and indicator logic to use request-derived content filters instead of the stored current_content_filters.
- Extend get_content_obj to accept optional content filters and delegate appropriately based on CMS version.
- Simplify prepopulated field handling by relying on the new grouper content filter helper instead of direct grouping calls.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Maintain django CMS grouper admin compatibility across versions by resolving request-specific content filters through a shared compatibility layer.

Bug Fixes:
- Ensure versioning admin grouper handling remains compatible with both django CMS 5.1 and earlier APIs.

Enhancements:
- Centralize request-based grouper content-filter resolution and use it consistently for queryset, indicators, field modifiers, content retrieval, and prepopulated fields.
- Allow content retrieval to pass filters when supported while preserving compatibility with older django CMS method signatures.

Tests:
- Add coverage for grouper content-filter and content-object handling across old and new django CMS admin APIs.