### PR TITLE
fix: State transitions did not clear version caches

### DIFF
--- a/djangocms_versioning/models.py
+++ b/djangocms_versioning/models.py
@@ -193,6 +193,14 @@ class Version(models.Model):
             self.content._latest_draft_version = drafts.first()
         return self.content._latest_draft_version
 
+    def _clear_content_version_caches(self):
+        content = self._state.fields_cache.get("content")
+        if content is None:
+            return
+        for attr in ("_version_cache", "_latest_draft_version"):
+            if hasattr(content, attr):
+                delattr(content, attr)
+
     def delete(self, using=None, keep_parents=False):
         """Deleting a version deletes the grouper
         as well if we are deleting the last version."""
@@ -237,6 +245,7 @@ class Version(models.Model):
             self.locked_by = None
 
         super().save(**kwargs)
+        self._clear_content_version_caches()
         # Only one draft version is allowed per unique grouping values.
         # Set all other drafts to archived
         if self.state == constants.DRAFT:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -272,7 +272,7 @@ class TestVersionQuerySet(CMSTestCase):
 
         cached_version = Version.objects.get_for_content(content)
         # Populate the latest draft version cache on the content object
-        latest_draft_version = Version.objects.get_latest_draft_version(content)
+        latest_draft_version = cached_version.get_latest_draft_version()
 
         self.assertEqual(cached_version.state, DRAFT)
         self.assertEqual(latest_draft_version.state, DRAFT)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -271,13 +271,18 @@ class TestVersionQuerySet(CMSTestCase):
         content = version.content
 
         cached_version = Version.objects.get_for_content(content)
+        # Populate the latest draft version cache on the content object
+        latest_draft_version = Version.objects.get_latest_draft_version(content)
 
         self.assertEqual(cached_version.state, DRAFT)
+        self.assertEqual(latest_draft_version.state, DRAFT)
         self.assertTrue(hasattr(content, "_version_cache"))
+        self.assertTrue(hasattr(content, "_latest_draft_version"))
 
         version.publish(user=version.created_by)
 
         self.assertFalse(hasattr(content, "_version_cache"))
+        self.assertFalse(hasattr(content, "_latest_draft_version"))
         self.assertEqual(Version.objects.get_for_content(content).state, PUBLISHED)
 
     def test_versioned_admin_manager(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -266,6 +266,20 @@ class TestVersionQuerySet(CMSTestCase):
         version = factories.PollVersionFactory()
         self.assertEqual(Version.objects.get_for_content(version.content), version)
 
+    def test_get_for_content_cache_invalidated_on_publish(self):
+        version = factories.PollVersionFactory()
+        content = version.content
+
+        cached_version = Version.objects.get_for_content(content)
+
+        self.assertEqual(cached_version.state, DRAFT)
+        self.assertTrue(hasattr(content, "_version_cache"))
+
+        version.publish(user=version.created_by)
+
+        self.assertFalse(hasattr(content, "_version_cache"))
+        self.assertEqual(Version.objects.get_for_content(content).state, PUBLISHED)
+
     def test_versioned_admin_manager(self):
         """With an extra helper method we can return the full queryset"""
         factories.PollVersionFactory()


### PR DESCRIPTION
## Summary by Sourcery

Ensure version-related caches on content objects are cleared when versions change state to keep get_for_content results consistent.

Bug Fixes:
- Invalidate cached version and latest draft references on content when a version is saved or published so state transitions reflect current data.

Tests:
- Add regression test to assert get_for_content cache is cleared and updated correctly when publishing a version.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.