### PR TITLE
fix: Harden prefetch for versionless content

### DIFF
--- a/djangocms_versioning/admin.py
+++ b/djangocms_versioning/admin.py
@@ -193,13 +193,15 @@ class StateIndicatorMixin(metaclass=MediaDefiningClass):
                     include_unpublished_archived=True,
                     **{field: getattr(self, field) for field in self._extra_grouping_fields},
                 )
-                for prefetched in getattr(obj, "_prefetched_contents", []):
-                    prefetched._prefetched_versions[0].content = prefetched  # Avoid fetching reverse
-                versions = (
-                    [content._prefetched_versions[0] for content in obj._prefetched_contents]
-                    if hasattr(obj, "_prefetched_contents")
-                    else None
-                )
+                if hasattr(obj, "_prefetched_contents"):
+                    versions = []
+                    for prefetched in obj._prefetched_contents:
+                        if not prefetched._prefetched_versions:
+                            # Content object without a version, e.g. created before versioning
+                            # was enabled: it has no state to indicate
+                            continue
+                        prefetched._prefetched_versions[0].content = prefetched  # Avoid fetching reverse
+                        versions.append(prefetched._prefetched_versions[0])
             else:  # Content Model
                 content_obj = obj
 
@@ -352,7 +354,11 @@ class ExtendedGrouperVersionAdminMixin(ExtendedListDisplayMixin):
             Prefetch(
                 reverse_name,
                 to_attr="_prefetched_contents",  # Needed for state indicators
-                queryset=self.content_model.admin_manager.filter(**self.current_content_filters)
+                # ``versions__isnull=False`` keeps content objects without a version (e.g. created
+                # before versioning was enabled) out of the cache, just like ``latest_content()`` does
+                queryset=self.content_model.admin_manager.filter(
+                    versions__isnull=False, **self.current_content_filters
+                )
                 .prefetch_related(Prefetch("versions", to_attr="_prefetched_versions"))
                 .annotate(content_is_latest=Value(True))  # We're only looking at the latest content in the qs
                 .order_by("-pk"),

--- a/djangocms_versioning/helpers.py
+++ b/djangocms_versioning/helpers.py
@@ -408,6 +408,9 @@ def get_latest_content_from_cache(
     def matches_filters(content):
         return all(getattr(content, field, None) == value for field, value in extra_grouping_fields.items())
 
+    # Ignore content objects without a version (e.g. created before versioning was enabled)
+    cache = [content for content in cache if getattr(content, "_prefetched_versions", None)]
+
     # Evaluate prefetched contents in python
     drafts = (content for content in cache if content._prefetched_versions[0].state == DRAFT)
     for content in drafts:

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -3412,6 +3412,46 @@ class DefaultGrouperAdminTestCase(CMSTestCase):
         can_change = modeladmin.can_change_content(request, public_version.content)
         self.assertFalse(can_change)
 
+    def test_changelist_with_content_without_version(self):
+        """Content objects without a version (e.g. created before versioning was enabled)
+        must neither be prefetched nor break the changelist. See #602."""
+        version = factories.PollVersionFactory(content__language="en")
+        poll = version.content.poll
+        # Content object of the same grouper which has no version
+        versionless_content = factories.PollContentFactory(poll=poll, language="en")
+
+        modeladmin = admin.site._registry[Poll]
+        modeladmin.language = "en"
+        request = self.get_request("/")
+        request.user = self.get_superuser()
+
+        obj = modeladmin.get_queryset(request).get(pk=poll.pk)
+
+        self.assertNotIn(versionless_content, obj._prefetched_contents)
+        self.assertEqual(modeladmin.get_content_obj(obj), version.content)
+
+        indicator = modeladmin.get_indicator_column(request)
+        self.assertIn("cms-pagetree-node-state-draft", indicator(obj))
+
+    def test_changelist_indicator_with_only_content_without_version(self):
+        """A grouper whose only content object has no version renders an empty
+        indicator instead of raising. See #602."""
+        poll = factories.PollFactory()
+        factories.PollContentFactory(poll=poll, language="en")
+
+        modeladmin = admin.site._registry[Poll]
+        modeladmin.language = "en"
+        request = self.get_request("/")
+        request.user = self.get_superuser()
+
+        obj = modeladmin.get_queryset(request).get(pk=poll.pk)
+
+        self.assertEqual(obj._prefetched_contents, [])
+        self.assertIsNone(modeladmin.get_content_obj(obj))
+
+        indicator = modeladmin.get_indicator_column(request)
+        self.assertIn("cms-pagetree-node-state-empty", indicator(obj))
+
     def test_prepopulated_fields_excluded_when_readonly(self):
         """Prepopulated fields referencing readonly content fields must be
         excluded to avoid a KeyError in Django's AdminForm. See #532."""

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -161,6 +161,38 @@ class TestGetLatestAdminViewableContent(CMSTestCase):
         self.assertEqual(en_content.language, "en")
         self.assertEqual(en_content.versions.first(), self.version)
 
+    def test_prefetched_content_without_version_is_ignored(self):
+        """Content objects without a version (e.g. created before versioning was enabled)
+        must not raise an IndexError but simply be skipped. See #602."""
+        content_obj = self.version.content
+        content_obj._prefetched_versions = [self.version]
+        versionless_content = factories.PageContentFactory(page=self.page, language="en")
+        versionless_content._prefetched_versions = []
+
+        self.page._prefetched_contents = [versionless_content, content_obj]  # order_by("-pk")
+
+        content = helpers.get_latest_admin_viewable_content(self.page, language="en")
+        self.assertEqual(content, content_obj)
+
+        content = helpers.get_latest_admin_viewable_content(
+            self.page, language="en", include_unpublished_archived=True
+        )
+        self.assertEqual(content, content_obj)
+
+    def test_prefetched_content_only_without_version_returns_none(self):
+        """A grouper whose only content object has no version has no viewable content. See #602."""
+        versionless_content = factories.PageContentFactory(page=self.page, language="de")
+        versionless_content._prefetched_versions = []
+
+        self.page._prefetched_contents = [versionless_content]
+
+        self.assertIsNone(helpers.get_latest_admin_viewable_content(self.page, language="de"))
+        self.assertIsNone(
+            helpers.get_latest_admin_viewable_content(
+                self.page, language="de", include_unpublished_archived=True
+            )
+        )
+
     def test_extra_grouping_fields_respects_language_without_prefetch(self):
         """Test that extra_grouping_fields (language) is respected when _prefetched_contents is not present"""
         # Create content for two different languages


### PR DESCRIPTION
## Summary by Sourcery

Harden versioning admin prefetch and indicator logic to safely handle content objects without associated versions, ensuring changelists and state indicators remain stable for legacy/versionless content.

Bug Fixes:
- Prevent IndexError and other errors when prefetched contents include items without versions in admin helpers and indicator rendering.
- Ensure changelist queries exclude versionless content from the prefetch cache while still rendering appropriate empty indicators when no versioned content exists.

Tests:
- Add admin changelist tests covering mixed versioned and versionless content and grouper objects with only versionless content.
- Add helper tests verifying that versionless prefetched content is ignored or results in no viewable content as appropriate.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Discord](https://www.django-cms.org/discord) to find a “pr review buddy” who is going to review my pull request.